### PR TITLE
fix: respect update.base config for source branch in wt new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ uv.toml
 
 # ai
 .claude/
+.idea

--- a/uv.lock
+++ b/uv.lock
@@ -203,8 +203,8 @@ wheels = [
 ]
 
 [[package]]
-name = "wt"
-version = "0.1.0"
+name = "wt-cli"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/wt/cli.py
+++ b/wt/cli.py
@@ -24,8 +24,8 @@ def cmd_new(args, cfg, repo_root):
     print("Fetching from origin...", flush=True)
     gitutil.fetch_origin(repo_root)
 
-    # Resolve source branch (auto-detect if default was used)
-    source_branch = args.from_branch
+    # Resolve source branch (use config if not specified)
+    source_branch = args.from_branch or cfg["update"]["base"]
     if source_branch == "origin/main":
         source_branch = gitutil.get_default_branch(repo_root)
 
@@ -609,7 +609,7 @@ def main():  # noqa: PLR0915, PLR0912
     parser_new = subparsers.add_parser("new", help="Create a new worktree")
     parser_new.add_argument("branch", help="Branch name")
     parser_new.add_argument(
-        "--from", dest="from_branch", default="origin/main", help="Source branch"
+        "--from", dest="from_branch", default=None, help="Source branch (default: from config)"
     )
     parser_new.add_argument("--track", action="store_true", help="Set upstream tracking")
     parser_new.add_argument("--force", action="store_true", help="Force creation, remove empty dir")


### PR DESCRIPTION
The --from argument had a hardcoded default of "origin/main" which prevented the update.base config setting from being used. Now defaults to None and falls back to cfg["update"]["base"], allowing users to configure a different default base branch (e.g., origin/dev) globally or per-repository.