### PR TITLE
Add wt rename command for moving and renaming worktrees

### DIFF
--- a/wt/gitutil.py
+++ b/wt/gitutil.py
@@ -530,3 +530,33 @@ def stash_pop(path: Path) -> None:
 
     """
     git("stash", "pop", cwd=path)
+
+
+def move_worktree(repo_root: Path, old_path: Path, new_path: Path) -> None:
+    """Move a worktree to a new location.
+
+    Args:
+        repo_root: Repository root path
+        old_path: Current worktree path
+        new_path: New worktree path
+
+    Raises:
+        GitError: If worktree move fails
+
+    """
+    git("worktree", "move", str(old_path), str(new_path), cwd=repo_root)
+
+
+def rename_branch(repo_root: Path, old_name: str, new_name: str) -> None:
+    """Rename a branch.
+
+    Args:
+        repo_root: Repository root path
+        old_name: Current branch name
+        new_name: New branch name
+
+    Raises:
+        GitError: If branch rename fails
+
+    """
+    git("branch", "-m", old_name, new_name, cwd=repo_root)


### PR DESCRIPTION
## Summary

Adds a new `wt rename` command that allows renaming worktrees with deterministic path resolution using the existing template system.

Inspired by workstack's rename functionality, but adapted to fit wt's philosophy of deterministic paths via templates.

## Features

- Move worktree to new location based on new branch name
- Optional `--rename-branch` flag to also rename the git branch
- Respects `auto_prefix` configuration
- Supports `--dry-run` to preview changes
- Creates parent directories as needed
- Validates new path and branch don't already exist

## Usage

```bash
# Rename worktree only (keeps branch name)
wt rename old-feature new-feature

# Rename both worktree and branch
wt rename old-feature new-feature --rename-branch

# Preview changes without executing
wt rename old-feature new-feature --dry-run
```

## Implementation

- Added `move_worktree()` and `rename_branch()` to `gitutil.py`
- Added `cmd_rename()` to `cli.py` with full error handling
- Uses existing path template system for consistent naming
- Respects auto_prefix for branch name matching

## Test plan

- [ ] Test renaming worktree without branch rename
- [ ] Test renaming worktree with branch rename
- [ ] Test with auto_prefix configured
- [ ] Test dry-run mode
- [ ] Test error cases (non-existent worktree, existing destination)