### PR TITLE
Add wt tree command to visualize worktree relationships

### DIFF
--- a/wt/gitutil.py
+++ b/wt/gitutil.py
@@ -530,3 +530,21 @@ def stash_pop(path: Path) -> None:
 
     """
     git("stash", "pop", cwd=path)
+
+
+def get_merge_base(cwd: Path, commit1: str, commit2: str) -> str | None:
+    """Get the merge base between two commits.
+
+    Args:
+        cwd: Working directory
+        commit1: First commit/branch
+        commit2: Second commit/branch
+
+    Returns:
+        Merge base SHA, or None if no common ancestor
+
+    """
+    try:
+        return git("merge-base", commit1, commit2, cwd=cwd)
+    except GitError:
+        return None


### PR DESCRIPTION
## Summary

Adds a new `wt tree` command that displays worktree relationships in a tree structure, showing which branches are based on which other branches.

Inspired by workstack's tree visualization, adapted to fit wt's philosophy using git merge-base to determine relationships.

## Features

- Shows all worktrees in a hierarchical tree structure
- Uses merge-base to determine parent-child relationships
- Highlights current worktree with `*` (simple) or `●` (rich)
- Supports both simple ASCII and box-drawing characters (`--rich`)
- Automatically detects closest parent branch for each worktree

## Algorithm

1. For each worktree, finds merge-base with potential parent branches
2. Selects parent with shortest distance (most recent common ancestor)
3. Builds tree starting from base branch (main/master)
4. Displays recursively with proper indentation

## Usage

```bash
# Simple ASCII tree
wt tree

# Box-drawing characters
wt tree --rich
```

## Example Output

Simple mode:
```
└── main
    ├── feature-a *
    │   └── feature-a-2
    └── feature-b
```

Rich mode:
```
└─ main
   ├─ feature-a ●
   │  └─ feature-a-2
   └─ feature-b
```

(The `*` or `●` indicates your current worktree)

## Implementation

- Added `get_merge_base()` to `gitutil.py`
- Added `cmd_tree()` with recursive tree printing
- Two formatting modes: `_print_tree_simple()` and `_print_tree_rich()`
- Uses git rev-list to count commits since merge-base
- Selects parent with minimum distance for accurate relationships

## Test Plan

### Basic Tree Visualization

1. **Setup test worktrees**:
   ```bash
   # Create a few worktrees
   wt new feature-a
   wt new feature-b
   
   # Create a nested worktree (branch off feature-a)
   cd $(wt where feature-a)
   git checkout -b feature-a-nested
   cd -
   wt new feature-a-nested --from feature-a
   ```

2. **Test simple output**:
   ```bash
   wt tree
   # Should show tree with ASCII characters
   # Should highlight current worktree with *
   ```

3. **Test rich output**:
   ```bash
   wt tree --rich
   # Should show tree with box-drawing characters
   # Should highlight current worktree with ●
   ```

4. **Test current worktree highlighting**:
   ```bash
   cd $(wt where feature-a)
   wt tree
   # feature-a should be marked with *
   
   cd $(wt where feature-b)
   wt tree --rich
   # feature-b should be marked with ●
   ```

### Parent Detection

5. **Test parent-child relationships**:
   ```bash
   # feature-a-nested should appear under feature-a
   wt tree
   # Verify the tree structure shows:
   # main
   #   ├── feature-a
   #   │   └── feature-a-nested
   #   └── feature-b
   ```

6. **Test with multiple levels**:
   ```bash
   # Create deeper nesting
   cd $(wt where feature-a-nested)
   git checkout -b feature-a-deep
   cd -
   wt new feature-a-deep --from feature-a-nested
   
   wt tree
   # Should show 3 levels of nesting
   ```

### Edge Cases

7. **Test with no worktrees**:
   ```bash
   # In a fresh repo with only main
   wt tree
   # Should show just main
   ```

8. **Test with config rich setting**:
   ```bash
   # If rich=true in config, should use rich by default
   wt tree  # uses config setting
   wt tree --rich  # forces rich mode
   ```

9. **Test from different directories**:
   ```bash
   cd /tmp
   wt --repo /path/to/repo tree
   # Should still work
   ```

### Integration with Other Commands

10. **Test after removing worktrees**:
    ```bash
    wt rm feature-b --yes
    wt tree
    # feature-b should not appear
    ```

11. **Test with multiple branches from same parent**:
    ```bash
    wt new feature-c
    wt new feature-d
    wt tree
    # Both should appear as children of main
    ```