### PR TITLE
Jfb/add completion and default repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ wt rm feature-x --yes         # Remove worktree
 # Run tests (when implemented)
 pytest tests/
 pytest tests/test_config.py  # Single test file
+
+# Generate shell completions (requires shtab in dev dependencies)
+wt completion bash > ~/.bash_completion.d/wt  # For bash
+wt completion zsh > ~/.zsh/completions/_wt    # For zsh
 ```
 
 ## Architecture
@@ -181,3 +185,30 @@ For each worktree:
 1. Add to `build_template_context()` in `paths.py`
 2. Update SPEC.md template variables section
 3. Variables are auto-injected into hooks as `WT_<VARNAME>`
+
+## Shell Completions
+
+Shell completions are provided via the `wt completion` command using `shtab`:
+
+- **Dependency**: `shtab>=1.6.0` is a **dev-only dependency** (not runtime)
+- **No runtime overhead**: Completions are generated statically, not on every tab press
+- **Supported shells**: bash, zsh, tcsh
+
+### Installation
+```bash
+# Install dev dependencies (includes shtab)
+pip install -e .[dev]
+
+# Generate completion script for your shell
+wt completion bash > ~/.bash_completion.d/wt
+wt completion zsh > ~/.zsh/completions/_wt
+
+# Or source directly
+source <(wt completion bash)
+```
+
+### Design Notes
+- If `shtab` is not available, the `completion` command shows an installation message
+- The completion command is only added to the parser if `shtab` is importable
+- Parser structure is duplicated in `cmd_completion()` to ensure accurate completions
+- Maintains the "stdlib only runtime" principle by keeping shtab as dev-only dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ packages = ["wt"]
 dev = [
     "pytest>=7.0.0",
     "pre-commit>=3.0.0",
+    "shtab>=1.6.0",
 ]
 
 [tool.ruff]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,3 +59,148 @@ auto_prefix = "global/"
             assert config["branches"]["auto_prefix"] == "local/"
         finally:
             wt.config.get_global_config_path = orig_func
+
+
+def test_default_config_includes_default_repo():
+    """Default config must include default_repo field with empty value."""
+    from wt.config import get_default_config
+    
+    default_config = get_default_config()
+    
+    assert "paths" in default_config
+    assert "default_repo" in default_config["paths"]
+    assert default_config["paths"]["default_repo"] == ""
+
+
+def test_load_config_with_default_repo_setting():
+    """Config loading should handle default_repo in global config."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        global_dir = Path(tmpdir) / "global"
+        global_dir.mkdir()
+        
+        # Create global config with default_repo
+        test_repo_path = "/path/to/default/repo"
+        (global_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{test_repo_path}"
+""")
+        
+        import wt.config
+        orig_func = wt.config.get_global_config_path
+        
+        def mock_global_path():
+            return global_dir / "config.toml"
+        
+        wt.config.get_global_config_path = mock_global_path
+        try:
+            config = load_config(repo_root=None)  # No repo context
+            assert config["paths"]["default_repo"] == test_repo_path
+        finally:
+            wt.config.get_global_config_path = orig_func
+
+
+def test_default_repo_merges_correctly():
+    """default_repo should merge correctly between global and local configs."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = Path(tmpdir) / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        
+        # Create global config with default_repo
+        global_dir = Path(tmpdir) / "global"
+        global_dir.mkdir()
+        (global_dir / "config.toml").write_text("""
+[paths]
+default_repo = "/global/repo"
+worktree_root = ""
+""")
+        
+        # Create local config with different default_repo
+        wt_dir = repo / ".wt"
+        wt_dir.mkdir()
+        (wt_dir / "config.toml").write_text("""
+[paths]
+default_repo = "/local/repo"
+""")
+        
+        import wt.config
+        orig_func = wt.config.get_global_config_path
+        
+        def mock_global_path():
+            return global_dir / "config.toml"
+        
+        wt.config.get_global_config_path = mock_global_path
+        try:
+            config = load_config(repo_root=repo)
+            # Local should override global
+            assert config["paths"]["default_repo"] == "/local/repo"
+            # Other paths settings should still be present
+            assert "worktree_root" in config["paths"]
+        finally:
+            wt.config.get_global_config_path = orig_func
+
+
+def test_empty_default_repo_evaluates_to_none():
+    """Empty string default_repo should be treated as None/unset."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        global_dir = Path(tmpdir) / "global"
+        global_dir.mkdir()
+        
+        # Create config with empty default_repo
+        (global_dir / "config.toml").write_text("""
+[paths]
+default_repo = ""
+""")
+        
+        import wt.config
+        orig_func = wt.config.get_global_config_path
+        
+        def mock_global_path():
+            return global_dir / "config.toml"
+        
+        wt.config.get_global_config_path = mock_global_path
+        try:
+            config = load_config(repo_root=None)
+            # Empty string should be preserved (caller will check for falsy value)
+            assert config["paths"]["default_repo"] == ""
+        finally:
+            wt.config.get_global_config_path = orig_func
+
+
+def test_cli_overrides_default_repo():
+    """CLI overrides should be able to override default_repo."""
+    from wt.config import load_config
+    
+    cli_overrides = {
+        "paths": {"default_repo": "/cli/override/repo"}
+    }
+    
+    config = load_config(repo_root=None, cli_overrides=cli_overrides)
+    assert config["paths"]["default_repo"] == "/cli/override/repo"
+
+
+def test_default_repo_with_tilde_in_config():
+    """Config should preserve tilde paths for later expansion."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        global_dir = Path(tmpdir) / "global"
+        global_dir.mkdir()
+        
+        # Create config with tilde path
+        (global_dir / "config.toml").write_text("""
+[paths]
+default_repo = "~/my-default-repo"
+""")
+        
+        import wt.config
+        orig_func = wt.config.get_global_config_path
+        
+        def mock_global_path():
+            return global_dir / "config.toml"
+        
+        wt.config.get_global_config_path = mock_global_path
+        try:
+            config = load_config(repo_root=None)
+            # Tilde should be preserved (expansion happens in discover_repo_root)
+            assert config["paths"]["default_repo"] == "~/my-default-repo"
+        finally:
+            wt.config.get_global_config_path = orig_func

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 import tempfile
 
-from wt.config import load_config, merge_configs
+import wt.config
+from wt.config import get_default_config, load_config, merge_configs
 
 
 def test_merge_configs_deep_override():
@@ -46,8 +47,6 @@ auto_prefix = "global/"
 """)
 
         # Load with override
-        import wt.config
-
         orig_func = wt.config.get_global_config_path
 
         def mock_global_path():
@@ -63,10 +62,8 @@ auto_prefix = "global/"
 
 def test_default_config_includes_default_repo():
     """Default config must include default_repo field with empty value."""
-    from wt.config import get_default_config
-    
     default_config = get_default_config()
-    
+
     assert "paths" in default_config
     assert "default_repo" in default_config["paths"]
     assert default_config["paths"]["default_repo"] == ""
@@ -77,20 +74,19 @@ def test_load_config_with_default_repo_setting():
     with tempfile.TemporaryDirectory() as tmpdir:
         global_dir = Path(tmpdir) / "global"
         global_dir.mkdir()
-        
+
         # Create global config with default_repo
         test_repo_path = "/path/to/default/repo"
         (global_dir / "config.toml").write_text(f"""
 [paths]
 default_repo = "{test_repo_path}"
 """)
-        
-        import wt.config
+
         orig_func = wt.config.get_global_config_path
-        
+
         def mock_global_path():
             return global_dir / "config.toml"
-        
+
         wt.config.get_global_config_path = mock_global_path
         try:
             config = load_config(repo_root=None)  # No repo context
@@ -105,7 +101,7 @@ def test_default_repo_merges_correctly():
         repo = Path(tmpdir) / "repo"
         repo.mkdir()
         (repo / ".git").mkdir()
-        
+
         # Create global config with default_repo
         global_dir = Path(tmpdir) / "global"
         global_dir.mkdir()
@@ -114,7 +110,7 @@ def test_default_repo_merges_correctly():
 default_repo = "/global/repo"
 worktree_root = ""
 """)
-        
+
         # Create local config with different default_repo
         wt_dir = repo / ".wt"
         wt_dir.mkdir()
@@ -122,13 +118,12 @@ worktree_root = ""
 [paths]
 default_repo = "/local/repo"
 """)
-        
-        import wt.config
+
         orig_func = wt.config.get_global_config_path
-        
+
         def mock_global_path():
             return global_dir / "config.toml"
-        
+
         wt.config.get_global_config_path = mock_global_path
         try:
             config = load_config(repo_root=repo)
@@ -145,19 +140,18 @@ def test_empty_default_repo_evaluates_to_none():
     with tempfile.TemporaryDirectory() as tmpdir:
         global_dir = Path(tmpdir) / "global"
         global_dir.mkdir()
-        
+
         # Create config with empty default_repo
         (global_dir / "config.toml").write_text("""
 [paths]
 default_repo = ""
 """)
-        
-        import wt.config
+
         orig_func = wt.config.get_global_config_path
-        
+
         def mock_global_path():
             return global_dir / "config.toml"
-        
+
         wt.config.get_global_config_path = mock_global_path
         try:
             config = load_config(repo_root=None)
@@ -169,12 +163,8 @@ default_repo = ""
 
 def test_cli_overrides_default_repo():
     """CLI overrides should be able to override default_repo."""
-    from wt.config import load_config
-    
-    cli_overrides = {
-        "paths": {"default_repo": "/cli/override/repo"}
-    }
-    
+    cli_overrides = {"paths": {"default_repo": "/cli/override/repo"}}
+
     config = load_config(repo_root=None, cli_overrides=cli_overrides)
     assert config["paths"]["default_repo"] == "/cli/override/repo"
 
@@ -184,19 +174,18 @@ def test_default_repo_with_tilde_in_config():
     with tempfile.TemporaryDirectory() as tmpdir:
         global_dir = Path(tmpdir) / "global"
         global_dir.mkdir()
-        
+
         # Create config with tilde path
         (global_dir / "config.toml").write_text("""
 [paths]
 default_repo = "~/my-default-repo"
 """)
-        
-        import wt.config
+
         orig_func = wt.config.get_global_config_path
-        
+
         def mock_global_path():
             return global_dir / "config.toml"
-        
+
         wt.config.get_global_config_path = mock_global_path
         try:
             config = load_config(repo_root=None)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,11 +3,14 @@
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
 
 import pytest
+
+from wt.cli import _complete_worktree_names
 
 
 def run_wt(args: list[str], cwd: Path, fake_home: Path, check=False, **kwargs):
@@ -99,8 +102,6 @@ def test_status_shows_dirty_worktrees(git_repo):
     list_result = run_wt(
         ["list", "--json"], repo, fake_home, capture_output=True, text=True, check=True
     )
-
-    import json
 
     worktrees = json.loads(list_result.stdout)
     wt_path = None
@@ -221,8 +222,6 @@ def test_new_worktree_with_existing_branch_not_detached(git_repo):
         ["list", "--json"], repo, fake_home, capture_output=True, text=True, check=True
     )
 
-    import json
-
     worktrees = json.loads(list_result.stdout)
     wt_path = None
     for wt in worktrees:
@@ -239,13 +238,13 @@ def test_new_worktree_with_existing_branch_not_detached(git_repo):
     )
 
     # Should NOT say "Not currently on any branch" (detached)
-    assert (
-        "Not currently on any branch" not in status_result.stdout
-    ), "Worktree is detached HEAD, should be on existing-branch"
+    assert "Not currently on any branch" not in status_result.stdout, (
+        "Worktree is detached HEAD, should be on existing-branch"
+    )
     # The branch name might have a prefix from config, so just check it contains "existing-branch"
-    assert (
-        "existing-branch" in status_result.stdout
-    ), f"Worktree should be on existing-branch, got: {status_result.stdout}"
+    assert "existing-branch" in status_result.stdout, (
+        f"Worktree should be on existing-branch, got: {status_result.stdout}"
+    )
 
 
 def test_new_from_current_moves_branch_to_worktree(git_repo):
@@ -316,7 +315,7 @@ def test_cli_uses_default_repo_from_non_git_directory(git_repo):
     """CLI should use default_repo when invoked from non-git directory."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create global config with default_repo
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -324,14 +323,14 @@ def test_cli_uses_default_repo_from_non_git_directory(git_repo):
 [paths]
 default_repo = "{repo}"
 """)
-    
+
     # Create non-git directory to run from
     non_git_dir = fake_home / "not_a_repo"
     non_git_dir.mkdir()
-    
+
     # Run status from non-git directory - should use default_repo
     result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=True)
-    
+
     # Should succeed and show the default repo's status
     assert "main" in result.stdout  # Should show main branch from default repo
 
@@ -340,17 +339,26 @@ def test_cli_prefers_current_repo_over_default_repo(git_repo):
     """When in git repo, CLI should ignore default_repo setting."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create another git repo to use as default
     other_repo = fake_home / "other_repo"
     other_repo.mkdir()
     subprocess.run(["git", "init"], cwd=other_repo, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=other_repo, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=other_repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=other_repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=other_repo,
+        check=True,
+        capture_output=True,
+    )
     (other_repo / "other.txt").write_text("other repo")
     subprocess.run(["git", "add", "."], cwd=other_repo, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "other commit"], cwd=other_repo, check=True, capture_output=True)
-    
+    subprocess.run(
+        ["git", "commit", "-m", "other commit"], cwd=other_repo, check=True, capture_output=True
+    )
+
     # Set default_repo to other_repo
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -358,10 +366,10 @@ def test_cli_prefers_current_repo_over_default_repo(git_repo):
 [paths]
 default_repo = "{other_repo}"
 """)
-    
+
     # Run from the original repo - should use current repo, not default
     result = run_wt(["list", "--json"], repo, fake_home, capture_output=True, text=True, check=True)
-    
+
     worktrees = json.loads(result.stdout)
     # Should show original repo path, not other_repo
     main_wt = next(wt for wt in worktrees if "main" in wt.get("branch", ""))
@@ -376,7 +384,7 @@ def test_cli_fails_gracefully_with_invalid_default_repo():
         fake_home.mkdir()
         non_git_dir = fake_home / "not_a_repo"
         non_git_dir.mkdir()
-        
+
         # Set default_repo to non-existent directory
         config_dir = fake_home / ".config" / "wt"
         config_dir.mkdir(parents=True)
@@ -384,12 +392,16 @@ def test_cli_fails_gracefully_with_invalid_default_repo():
 [paths]
 default_repo = "/does/not/exist"
 """)
-        
+
         # Run from non-git directory - should fail with clear message
-        result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=False)
-        
+        result = run_wt(
+            ["status"], non_git_dir, fake_home, capture_output=True, text=True, check=False
+        )
+
         assert result.returncode != 0
-        assert "Default repository" in result.stderr or "not a valid git repository" in result.stderr
+        assert (
+            "Default repository" in result.stderr or "not a valid git repository" in result.stderr
+        )
 
 
 def test_cli_fails_gracefully_with_non_git_default_repo():
@@ -399,11 +411,11 @@ def test_cli_fails_gracefully_with_non_git_default_repo():
         fake_home.mkdir()
         non_git_dir = fake_home / "not_a_repo"
         non_git_dir.mkdir()
-        
+
         # Create a directory that's not a git repo
         not_git = fake_home / "not_git_repo"
         not_git.mkdir()
-        
+
         # Set default_repo to non-git directory
         config_dir = fake_home / ".config" / "wt"
         config_dir.mkdir(parents=True)
@@ -411,19 +423,22 @@ def test_cli_fails_gracefully_with_non_git_default_repo():
 [paths]
 default_repo = "{not_git}"
 """)
-        
+
         # Run from non-git directory - should fail with clear message
-        result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=False)
-        
+        result = run_wt(
+            ["status"], non_git_dir, fake_home, capture_output=True, text=True, check=False
+        )
+
         assert result.returncode != 0
-        assert "Default repository" in result.stderr and "not a valid git repository" in result.stderr
+        assert "Default repository" in result.stderr
+        assert "not a valid git repository" in result.stderr
 
 
 def test_cli_works_without_default_repo_from_git_directory(git_repo):
     """CLI should work normally when no default_repo is set but we're in a git repo."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create global config without default_repo (or with empty default_repo)
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -431,7 +446,7 @@ def test_cli_works_without_default_repo_from_git_directory(git_repo):
 [branches]
 auto_prefix = ""
 """)
-    
+
     # Should work fine from git repo
     result = run_wt(["status"], repo, fake_home, capture_output=True, text=True, check=True)
     assert "main" in result.stdout
@@ -441,7 +456,7 @@ def test_new_worktree_uses_default_repo(git_repo):
     """Creating new worktree should work when using default_repo."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create global config with default_repo
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -449,16 +464,18 @@ def test_new_worktree_uses_default_repo(git_repo):
 [paths]
 default_repo = "{repo}"
 """)
-    
+
     # Create non-git directory to run from
     non_git_dir = fake_home / "not_a_repo"
     non_git_dir.mkdir()
-    
+
     # Create new worktree from non-git directory - should use default_repo
-    result = run_wt(["new", "feature-from-default"], non_git_dir, fake_home, capture_output=True, text=True)
-    
+    result = run_wt(
+        ["new", "feature-from-default"], non_git_dir, fake_home, capture_output=True, text=True
+    )
+
     assert result.returncode == 0, f"Failed: {result.stderr}"
-    
+
     # Verify worktree was created in default repo
     wt_list = subprocess.run(
         ["git", "worktree", "list"], cwd=repo, capture_output=True, text=True, check=True
@@ -470,14 +487,13 @@ def test_default_repo_with_tilde_expansion(git_repo):
     """CLI should expand ~ in default_repo paths."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Move repo to fake home to test tilde expansion
     home_repo = fake_home / "my_repo"
-    
+
     # Copy the git repo to fake home (move files and .git)
-    import shutil
     shutil.copytree(repo, home_repo)
-    
+
     # Create global config with tilde path
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -485,14 +501,14 @@ def test_default_repo_with_tilde_expansion(git_repo):
 [paths]
 default_repo = "~/my_repo"
 """)
-    
+
     # Create non-git directory to run from
     non_git_dir = fake_home / "not_a_repo"
     non_git_dir.mkdir()
-    
+
     # Run status from non-git directory - should expand ~ and use home repo
     result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=True)
-    
+
     # Should succeed and show the home repo's status
     assert "main" in result.stdout
 
@@ -501,10 +517,10 @@ def test_completion_works_with_default_repo(git_repo):
     """Shell completion should work when using default_repo."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create a worktree first so completion has something to complete
     run_wt(["new", "completion-test"], repo, fake_home, check=True, capture_output=True)
-    
+
     # Create global config with default_repo
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -512,15 +528,15 @@ def test_completion_works_with_default_repo(git_repo):
 [paths]
 default_repo = "{repo}"
 """)
-    
+
     # Create non-git directory to run from
     non_git_dir = fake_home / "not_a_repo"
     non_git_dir.mkdir()
-    
+
     # Test that completion function can find worktrees using default_repo
     # We test this by checking if the completion command would succeed
     # (The actual completion testing would require more complex shell integration)
-    
+
     # For now, just verify that wt commands work from non-git directory
     result = run_wt(["list"], non_git_dir, fake_home, capture_output=True, text=True, check=True)
     assert "completion-test" in result.stdout
@@ -530,7 +546,7 @@ def test_doctor_shows_default_repo_setting(git_repo):
     """Doctor command should display default_repo configuration."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create global config with default_repo
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -538,10 +554,10 @@ def test_doctor_shows_default_repo_setting(git_repo):
 [paths]
 default_repo = "{repo}"
 """)
-    
+
     # Run doctor from git repo
     result = run_wt(["doctor"], repo, fake_home, capture_output=True, text=True, check=True)
-    
+
     # Doctor should show the default_repo setting
     assert str(repo) in result.stdout or "default_repo" in result.stdout
 
@@ -550,34 +566,37 @@ def test_completion_function_works_in_git_directory(git_repo):
     """Completion function should work normally when in a git directory."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create some worktrees to complete
     run_wt(["new", "feature-one"], repo, fake_home, check=True, capture_output=True)
     run_wt(["new", "feature-two"], repo, fake_home, check=True, capture_output=True)
-    
+
     # Test the completion function directly
-    import sys
-    import os
-    sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
-    
+    sys.path.insert(
+        0,
+        str(
+            Path(
+                "/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt"
+            )
+        ),
+    )
+
     # Set up environment to simulate being in the git repo
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     original_home = os.environ.get("HOME")
-    
+
     try:
         os.chdir(repo)
         os.environ["HOME"] = str(fake_home)
-        
-        from wt.cli import _complete_worktree_names
-        
+
         branch_names = _complete_worktree_names()
-        
+
         # Should return branch names from worktrees
         assert isinstance(branch_names, list)
         assert "main" in branch_names
         assert "feature-one" in branch_names
         assert "feature-two" in branch_names
-        
+
     finally:
         os.chdir(original_cwd)
         if original_home:
@@ -590,10 +609,10 @@ def test_completion_function_uses_default_repo_from_non_git_directory(git_repo):
     """Completion function should use default_repo when in non-git directory."""
     repo = git_repo["repo"]
     fake_home = git_repo["fake_home"]
-    
+
     # Create some worktrees to complete
     run_wt(["new", "completion-branch"], repo, fake_home, check=True, capture_output=True)
-    
+
     # Create global config with default_repo
     config_dir = fake_home / ".config" / "wt"
     config_dir.mkdir(parents=True)
@@ -601,32 +620,35 @@ def test_completion_function_uses_default_repo_from_non_git_directory(git_repo):
 [paths]
 default_repo = "{repo}"
 """)
-    
+
     # Create non-git directory
     non_git_dir = fake_home / "not_git"
     non_git_dir.mkdir()
-    
+
     # Test completion function from non-git directory
-    import sys
-    import os
-    sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
-    
-    original_cwd = os.getcwd()
+    sys.path.insert(
+        0,
+        str(
+            Path(
+                "/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt"
+            )
+        ),
+    )
+
+    original_cwd = Path.cwd()
     original_home = os.environ.get("HOME")
-    
+
     try:
         os.chdir(non_git_dir)  # Change to non-git directory
         os.environ["HOME"] = str(fake_home)
-        
-        from wt.cli import _complete_worktree_names
-        
+
         branch_names = _complete_worktree_names()
-        
+
         # Should still return branch names using default_repo
         assert isinstance(branch_names, list)
         assert "main" in branch_names
         assert "completion-branch" in branch_names
-        
+
     finally:
         os.chdir(original_cwd)
         if original_home:
@@ -642,7 +664,7 @@ def test_completion_function_handles_missing_default_repo_gracefully():
         fake_home.mkdir()
         non_git_dir = fake_home / "not_git"
         non_git_dir.mkdir()
-        
+
         # No default_repo configured
         config_dir = fake_home / ".config" / "wt"
         config_dir.mkdir(parents=True)
@@ -650,26 +672,29 @@ def test_completion_function_handles_missing_default_repo_gracefully():
 [branches]
 auto_prefix = ""
 """)
-        
-        import sys
-        import os
-        sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
-        
-        original_cwd = os.getcwd()
+
+        sys.path.insert(
+            0,
+            str(
+                Path(
+                    "/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt"
+                )
+            ),
+        )
+
+        original_cwd = Path.cwd()
         original_home = os.environ.get("HOME")
-        
+
         try:
             os.chdir(non_git_dir)
             os.environ["HOME"] = str(fake_home)
-            
-            from wt.cli import _complete_worktree_names
-            
+
             branch_names = _complete_worktree_names()
-            
+
             # Should return empty list gracefully, not crash
             assert isinstance(branch_names, list)
             assert len(branch_names) == 0
-            
+
         finally:
             os.chdir(original_cwd)
             if original_home:
@@ -685,7 +710,7 @@ def test_completion_function_handles_invalid_default_repo_gracefully():
         fake_home.mkdir()
         non_git_dir = fake_home / "not_git"
         non_git_dir.mkdir()
-        
+
         # Configure invalid default_repo
         config_dir = fake_home / ".config" / "wt"
         config_dir.mkdir(parents=True)
@@ -693,26 +718,29 @@ def test_completion_function_handles_invalid_default_repo_gracefully():
 [paths]
 default_repo = "/does/not/exist"
 """)
-        
-        import sys
-        import os
-        sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
-        
-        original_cwd = os.getcwd()
+
+        sys.path.insert(
+            0,
+            str(
+                Path(
+                    "/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt"
+                )
+            ),
+        )
+
+        original_cwd = Path.cwd()
         original_home = os.environ.get("HOME")
-        
+
         try:
             os.chdir(non_git_dir)
             os.environ["HOME"] = str(fake_home)
-            
-            from wt.cli import _complete_worktree_names
-            
+
             branch_names = _complete_worktree_names()
-            
+
             # Should return empty list gracefully, not crash
             assert isinstance(branch_names, list)
             assert len(branch_names) == 0
-            
+
         finally:
             os.chdir(original_cwd)
             if original_home:
@@ -728,20 +756,33 @@ def test_completion_function_filters_origin_prefix():
         fake_home.mkdir()
         repo = fake_home / "test_repo"
         repo.mkdir()
-        
+
         # Set up a git repo with origin/ prefixed branches
         subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
         (repo / "README.md").write_text("test")
         subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"], cwd=repo, check=True, capture_output=True
+        )
         subprocess.run(["git", "branch", "-M", "main"], cwd=repo, check=True, capture_output=True)
-        
+
         # Create worktrees - these will have local branch names
-        subprocess.run(["git", "worktree", "add", str(repo.parent / "wt1"), "-b", "feature-test"], 
-                      cwd=repo, check=True, capture_output=True)
-        
+        subprocess.run(
+            ["git", "worktree", "add", str(repo.parent / "wt1"), "-b", "feature-test"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
         # Configure default_repo
         config_dir = fake_home / ".config" / "wt"
         config_dir.mkdir(parents=True)
@@ -749,29 +790,32 @@ def test_completion_function_filters_origin_prefix():
 [paths]
 default_repo = "{repo}"
 """)
-        
-        import sys
-        import os
-        sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
-        
-        original_cwd = os.getcwd()
+
+        sys.path.insert(
+            0,
+            str(
+                Path(
+                    "/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt"
+                )
+            ),
+        )
+
+        original_cwd = Path.cwd()
         original_home = os.environ.get("HOME")
-        
+
         try:
             os.chdir(repo)
             os.environ["HOME"] = str(fake_home)
-            
-            from wt.cli import _complete_worktree_names
-            
+
             branch_names = _complete_worktree_names()
-            
+
             # Should have branch names without origin/ prefix
             assert isinstance(branch_names, list)
             assert "main" in branch_names
             assert "feature-test" in branch_names
             # Should not have origin/ prefixes
             assert not any(name.startswith("origin/") for name in branch_names)
-            
+
         finally:
             os.chdir(original_cwd)
             if original_home:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -310,3 +310,471 @@ def test_new_from_current_errors_with_branch_arg(git_repo):
 
     assert result.returncode != 0, "Should fail when both branch and --from-current provided"
     assert "Cannot specify both" in result.stderr
+
+
+def test_cli_uses_default_repo_from_non_git_directory(git_repo):
+    """CLI should use default_repo when invoked from non-git directory."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create global config with default_repo
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{repo}"
+""")
+    
+    # Create non-git directory to run from
+    non_git_dir = fake_home / "not_a_repo"
+    non_git_dir.mkdir()
+    
+    # Run status from non-git directory - should use default_repo
+    result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=True)
+    
+    # Should succeed and show the default repo's status
+    assert "main" in result.stdout  # Should show main branch from default repo
+
+
+def test_cli_prefers_current_repo_over_default_repo(git_repo):
+    """When in git repo, CLI should ignore default_repo setting."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create another git repo to use as default
+    other_repo = fake_home / "other_repo"
+    other_repo.mkdir()
+    subprocess.run(["git", "init"], cwd=other_repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=other_repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=other_repo, check=True, capture_output=True)
+    (other_repo / "other.txt").write_text("other repo")
+    subprocess.run(["git", "add", "."], cwd=other_repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "other commit"], cwd=other_repo, check=True, capture_output=True)
+    
+    # Set default_repo to other_repo
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{other_repo}"
+""")
+    
+    # Run from the original repo - should use current repo, not default
+    result = run_wt(["list", "--json"], repo, fake_home, capture_output=True, text=True, check=True)
+    
+    worktrees = json.loads(result.stdout)
+    # Should show original repo path, not other_repo
+    main_wt = next(wt for wt in worktrees if "main" in wt.get("branch", ""))
+    assert str(repo) in main_wt["path"]
+    assert str(other_repo) not in main_wt["path"]
+
+
+def test_cli_fails_gracefully_with_invalid_default_repo():
+    """CLI should give clear error when default_repo is invalid."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_home = Path(tmpdir) / "fake_home"
+        fake_home.mkdir()
+        non_git_dir = fake_home / "not_a_repo"
+        non_git_dir.mkdir()
+        
+        # Set default_repo to non-existent directory
+        config_dir = fake_home / ".config" / "wt"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").write_text("""
+[paths]
+default_repo = "/does/not/exist"
+""")
+        
+        # Run from non-git directory - should fail with clear message
+        result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=False)
+        
+        assert result.returncode != 0
+        assert "Default repository" in result.stderr or "not a valid git repository" in result.stderr
+
+
+def test_cli_fails_gracefully_with_non_git_default_repo():
+    """CLI should give clear error when default_repo is not a git repository."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_home = Path(tmpdir) / "fake_home"
+        fake_home.mkdir()
+        non_git_dir = fake_home / "not_a_repo"
+        non_git_dir.mkdir()
+        
+        # Create a directory that's not a git repo
+        not_git = fake_home / "not_git_repo"
+        not_git.mkdir()
+        
+        # Set default_repo to non-git directory
+        config_dir = fake_home / ".config" / "wt"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{not_git}"
+""")
+        
+        # Run from non-git directory - should fail with clear message
+        result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=False)
+        
+        assert result.returncode != 0
+        assert "Default repository" in result.stderr and "not a valid git repository" in result.stderr
+
+
+def test_cli_works_without_default_repo_from_git_directory(git_repo):
+    """CLI should work normally when no default_repo is set but we're in a git repo."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create global config without default_repo (or with empty default_repo)
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text("""
+[branches]
+auto_prefix = ""
+""")
+    
+    # Should work fine from git repo
+    result = run_wt(["status"], repo, fake_home, capture_output=True, text=True, check=True)
+    assert "main" in result.stdout
+
+
+def test_new_worktree_uses_default_repo(git_repo):
+    """Creating new worktree should work when using default_repo."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create global config with default_repo
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{repo}"
+""")
+    
+    # Create non-git directory to run from
+    non_git_dir = fake_home / "not_a_repo"
+    non_git_dir.mkdir()
+    
+    # Create new worktree from non-git directory - should use default_repo
+    result = run_wt(["new", "feature-from-default"], non_git_dir, fake_home, capture_output=True, text=True)
+    
+    assert result.returncode == 0, f"Failed: {result.stderr}"
+    
+    # Verify worktree was created in default repo
+    wt_list = subprocess.run(
+        ["git", "worktree", "list"], cwd=repo, capture_output=True, text=True, check=True
+    )
+    assert "feature-from-default" in wt_list.stdout
+
+
+def test_default_repo_with_tilde_expansion(git_repo):
+    """CLI should expand ~ in default_repo paths."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Move repo to fake home to test tilde expansion
+    home_repo = fake_home / "my_repo"
+    
+    # Copy the git repo to fake home (move files and .git)
+    import shutil
+    shutil.copytree(repo, home_repo)
+    
+    # Create global config with tilde path
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text("""
+[paths]
+default_repo = "~/my_repo"
+""")
+    
+    # Create non-git directory to run from
+    non_git_dir = fake_home / "not_a_repo"
+    non_git_dir.mkdir()
+    
+    # Run status from non-git directory - should expand ~ and use home repo
+    result = run_wt(["status"], non_git_dir, fake_home, capture_output=True, text=True, check=True)
+    
+    # Should succeed and show the home repo's status
+    assert "main" in result.stdout
+
+
+def test_completion_works_with_default_repo(git_repo):
+    """Shell completion should work when using default_repo."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create a worktree first so completion has something to complete
+    run_wt(["new", "completion-test"], repo, fake_home, check=True, capture_output=True)
+    
+    # Create global config with default_repo
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{repo}"
+""")
+    
+    # Create non-git directory to run from
+    non_git_dir = fake_home / "not_a_repo"
+    non_git_dir.mkdir()
+    
+    # Test that completion function can find worktrees using default_repo
+    # We test this by checking if the completion command would succeed
+    # (The actual completion testing would require more complex shell integration)
+    
+    # For now, just verify that wt commands work from non-git directory
+    result = run_wt(["list"], non_git_dir, fake_home, capture_output=True, text=True, check=True)
+    assert "completion-test" in result.stdout
+
+
+def test_doctor_shows_default_repo_setting(git_repo):
+    """Doctor command should display default_repo configuration."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create global config with default_repo
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{repo}"
+""")
+    
+    # Run doctor from git repo
+    result = run_wt(["doctor"], repo, fake_home, capture_output=True, text=True, check=True)
+    
+    # Doctor should show the default_repo setting
+    assert str(repo) in result.stdout or "default_repo" in result.stdout
+
+
+def test_completion_function_works_in_git_directory(git_repo):
+    """Completion function should work normally when in a git directory."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create some worktrees to complete
+    run_wt(["new", "feature-one"], repo, fake_home, check=True, capture_output=True)
+    run_wt(["new", "feature-two"], repo, fake_home, check=True, capture_output=True)
+    
+    # Test the completion function directly
+    import sys
+    import os
+    sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
+    
+    # Set up environment to simulate being in the git repo
+    original_cwd = os.getcwd()
+    original_home = os.environ.get("HOME")
+    
+    try:
+        os.chdir(repo)
+        os.environ["HOME"] = str(fake_home)
+        
+        from wt.cli import _complete_worktree_names
+        
+        branch_names = _complete_worktree_names()
+        
+        # Should return branch names from worktrees
+        assert isinstance(branch_names, list)
+        assert "main" in branch_names
+        assert "feature-one" in branch_names
+        assert "feature-two" in branch_names
+        
+    finally:
+        os.chdir(original_cwd)
+        if original_home:
+            os.environ["HOME"] = original_home
+        elif "HOME" in os.environ:
+            del os.environ["HOME"]
+
+
+def test_completion_function_uses_default_repo_from_non_git_directory(git_repo):
+    """Completion function should use default_repo when in non-git directory."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+    
+    # Create some worktrees to complete
+    run_wt(["new", "completion-branch"], repo, fake_home, check=True, capture_output=True)
+    
+    # Create global config with default_repo
+    config_dir = fake_home / ".config" / "wt"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{repo}"
+""")
+    
+    # Create non-git directory
+    non_git_dir = fake_home / "not_git"
+    non_git_dir.mkdir()
+    
+    # Test completion function from non-git directory
+    import sys
+    import os
+    sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
+    
+    original_cwd = os.getcwd()
+    original_home = os.environ.get("HOME")
+    
+    try:
+        os.chdir(non_git_dir)  # Change to non-git directory
+        os.environ["HOME"] = str(fake_home)
+        
+        from wt.cli import _complete_worktree_names
+        
+        branch_names = _complete_worktree_names()
+        
+        # Should still return branch names using default_repo
+        assert isinstance(branch_names, list)
+        assert "main" in branch_names
+        assert "completion-branch" in branch_names
+        
+    finally:
+        os.chdir(original_cwd)
+        if original_home:
+            os.environ["HOME"] = original_home
+        elif "HOME" in os.environ:
+            del os.environ["HOME"]
+
+
+def test_completion_function_handles_missing_default_repo_gracefully():
+    """Completion function should return empty list when no repo found."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_home = Path(tmpdir) / "home"
+        fake_home.mkdir()
+        non_git_dir = fake_home / "not_git"
+        non_git_dir.mkdir()
+        
+        # No default_repo configured
+        config_dir = fake_home / ".config" / "wt"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").write_text("""
+[branches]
+auto_prefix = ""
+""")
+        
+        import sys
+        import os
+        sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
+        
+        original_cwd = os.getcwd()
+        original_home = os.environ.get("HOME")
+        
+        try:
+            os.chdir(non_git_dir)
+            os.environ["HOME"] = str(fake_home)
+            
+            from wt.cli import _complete_worktree_names
+            
+            branch_names = _complete_worktree_names()
+            
+            # Should return empty list gracefully, not crash
+            assert isinstance(branch_names, list)
+            assert len(branch_names) == 0
+            
+        finally:
+            os.chdir(original_cwd)
+            if original_home:
+                os.environ["HOME"] = original_home
+            elif "HOME" in os.environ:
+                del os.environ["HOME"]
+
+
+def test_completion_function_handles_invalid_default_repo_gracefully():
+    """Completion function should handle invalid default_repo gracefully."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_home = Path(tmpdir) / "home"
+        fake_home.mkdir()
+        non_git_dir = fake_home / "not_git"
+        non_git_dir.mkdir()
+        
+        # Configure invalid default_repo
+        config_dir = fake_home / ".config" / "wt"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").write_text("""
+[paths]
+default_repo = "/does/not/exist"
+""")
+        
+        import sys
+        import os
+        sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
+        
+        original_cwd = os.getcwd()
+        original_home = os.environ.get("HOME")
+        
+        try:
+            os.chdir(non_git_dir)
+            os.environ["HOME"] = str(fake_home)
+            
+            from wt.cli import _complete_worktree_names
+            
+            branch_names = _complete_worktree_names()
+            
+            # Should return empty list gracefully, not crash
+            assert isinstance(branch_names, list)
+            assert len(branch_names) == 0
+            
+        finally:
+            os.chdir(original_cwd)
+            if original_home:
+                os.environ["HOME"] = original_home
+            elif "HOME" in os.environ:
+                del os.environ["HOME"]
+
+
+def test_completion_function_filters_origin_prefix():
+    """Completion function should remove 'origin/' prefix from branch names."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_home = Path(tmpdir) / "home"
+        fake_home.mkdir()
+        repo = fake_home / "test_repo"
+        repo.mkdir()
+        
+        # Set up a git repo with origin/ prefixed branches
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True, capture_output=True)
+        (repo / "README.md").write_text("test")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "branch", "-M", "main"], cwd=repo, check=True, capture_output=True)
+        
+        # Create worktrees - these will have local branch names
+        subprocess.run(["git", "worktree", "add", str(repo.parent / "wt1"), "-b", "feature-test"], 
+                      cwd=repo, check=True, capture_output=True)
+        
+        # Configure default_repo
+        config_dir = fake_home / ".config" / "wt"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").write_text(f"""
+[paths]
+default_repo = "{repo}"
+""")
+        
+        import sys
+        import os
+        sys.path.insert(0, str(Path("/private/var/folders/xn/45d91fgd0f18hg7q88yqmgl40000gn/T/fleet-4dcb3ypngv3nu3ojatzn/wt")))
+        
+        original_cwd = os.getcwd()
+        original_home = os.environ.get("HOME")
+        
+        try:
+            os.chdir(repo)
+            os.environ["HOME"] = str(fake_home)
+            
+            from wt.cli import _complete_worktree_names
+            
+            branch_names = _complete_worktree_names()
+            
+            # Should have branch names without origin/ prefix
+            assert isinstance(branch_names, list)
+            assert "main" in branch_names
+            assert "feature-test" in branch_names
+            # Should not have origin/ prefixes
+            assert not any(name.startswith("origin/") for name in branch_names)
+            
+        finally:
+            os.chdir(original_cwd)
+            if original_home:
+                os.environ["HOME"] = original_home
+            elif "HOME" in os.environ:
+                del os.environ["HOME"]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,8 +1,11 @@
 """Path template tests - only the failure modes that matter."""
 
 import pytest
+import subprocess
+import tempfile
+from pathlib import Path
 
-from wt.paths import build_template_context, render_path_template
+from wt.paths import build_template_context, render_path_template, discover_repo_root, RepoDiscoveryError
 
 
 def test_template_renders_all_variables(tmp_path):
@@ -60,3 +63,309 @@ def test_unknown_variable_raises_error():
 
     with pytest.raises((KeyError, ValueError)):
         render_path_template(template, context)
+
+
+@pytest.fixture
+def real_git_repo():
+    """Create a real git repository for testing discover_repo_root."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_path = Path(tmpdir) / "test_repo"
+        repo_path.mkdir()
+        
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo_path, check=True, capture_output=True)
+        
+        # Create initial commit
+        (repo_path / "README.md").write_text("test")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=repo_path, check=True, capture_output=True)
+        
+        yield repo_path
+
+
+@pytest.fixture
+def non_git_directory():
+    """Create a non-git directory for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        non_git_path = Path(tmpdir) / "not_a_repo"
+        non_git_path.mkdir()
+        yield non_git_path
+
+
+def test_discover_repo_root_finds_current_repo(real_git_repo):
+    """discover_repo_root() should find the current git repository."""
+    repo_root = discover_repo_root(start=real_git_repo)
+    # Use resolve() to handle symlinks (macOS /var -> /private/var)
+    assert repo_root.resolve() == real_git_repo.resolve()
+
+
+def test_discover_repo_root_works_from_subdirectory(real_git_repo):
+    """discover_repo_root() should find repo root from subdirectories."""
+    subdir = real_git_repo / "subdir" / "deep"
+    subdir.mkdir(parents=True)
+    
+    repo_root = discover_repo_root(start=subdir)
+    assert repo_root.resolve() == real_git_repo.resolve()
+
+
+def test_discover_repo_root_fails_without_default_repo(non_git_directory):
+    """discover_repo_root() should fail when not in git repo and no default_repo."""
+    with pytest.raises(RepoDiscoveryError) as exc_info:
+        discover_repo_root(start=non_git_directory)
+    
+    assert "Not in a git repository" in str(exc_info.value)
+
+
+def test_discover_repo_root_uses_valid_default_repo(real_git_repo, non_git_directory):
+    """discover_repo_root() should use default_repo when not in a git directory."""
+    repo_root = discover_repo_root(start=non_git_directory, default_repo=str(real_git_repo))
+    assert repo_root.resolve() == real_git_repo.resolve()
+
+
+def test_discover_repo_root_expands_tilde_in_default_repo(real_git_repo, non_git_directory):
+    """discover_repo_root() should expand ~ in default_repo paths."""
+    # Create a repo in a fake home directory
+    fake_home = real_git_repo.parent / "fake_home"
+    fake_home.mkdir()
+    home_repo = fake_home / "repo"
+    home_repo.mkdir()
+    
+    # Initialize git repo in fake home
+    subprocess.run(["git", "init"], cwd=home_repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=home_repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=home_repo, check=True, capture_output=True)
+    (home_repo / "README.md").write_text("test")
+    subprocess.run(["git", "add", "."], cwd=home_repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=home_repo, check=True, capture_output=True)
+    
+    # Mock os.path.expanduser to return our fake home
+    import os
+    import os.path
+    original_expanduser = os.path.expanduser
+    
+    def mock_expanduser(path):
+        if path.startswith("~"):
+            return path.replace("~", str(fake_home), 1)
+        return original_expanduser(path)
+    
+    os.path.expanduser = mock_expanduser
+    
+    try:
+        repo_root = discover_repo_root(start=non_git_directory, default_repo="~/repo")
+        assert repo_root.resolve() == home_repo.resolve()
+    finally:
+        os.path.expanduser = original_expanduser
+
+
+def test_discover_repo_root_fails_with_invalid_default_repo(non_git_directory):
+    """discover_repo_root() should fail when default_repo is not a git repository."""
+    invalid_path = non_git_directory / "not_a_git_repo"
+    invalid_path.mkdir()
+    
+    with pytest.raises(RepoDiscoveryError) as exc_info:
+        discover_repo_root(start=non_git_directory, default_repo=str(invalid_path))
+    
+    assert "Default repository" in str(exc_info.value)
+    assert "not a valid git repository" in str(exc_info.value)
+
+
+def test_discover_repo_root_fails_with_nonexistent_default_repo(non_git_directory):
+    """discover_repo_root() should fail when default_repo doesn't exist."""
+    nonexistent_path = non_git_directory / "does_not_exist"
+    
+    with pytest.raises(RepoDiscoveryError) as exc_info:
+        discover_repo_root(start=non_git_directory, default_repo=str(nonexistent_path))
+    
+    assert "Default repository" in str(exc_info.value)
+    assert "not a valid git repository" in str(exc_info.value)
+
+
+def test_discover_repo_root_prefers_current_repo_over_default(real_git_repo):
+    """When in a git repo, discover_repo_root() should ignore default_repo."""
+    # Create another git repo for default
+    with tempfile.TemporaryDirectory() as tmpdir:
+        default_repo = Path(tmpdir) / "default"
+        default_repo.mkdir()
+        subprocess.run(["git", "init"], cwd=default_repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=default_repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=default_repo, check=True, capture_output=True)
+        
+        # Should return the current repo, not the default
+        repo_root = discover_repo_root(start=real_git_repo, default_repo=str(default_repo))
+        assert repo_root.resolve() == real_git_repo.resolve()
+
+
+def test_discover_repo_root_handles_worktree_correctly(real_git_repo):
+    """discover_repo_root() should return main repo root even from worktrees."""
+    # Create a worktree
+    worktrees_dir = real_git_repo.parent / "worktrees"
+    worktrees_dir.mkdir()
+    worktree_path = worktrees_dir / "feature-branch"
+    
+    subprocess.run(
+        ["git", "worktree", "add", str(worktree_path), "-b", "feature-branch"],
+        cwd=real_git_repo,
+        check=True,
+        capture_output=True
+    )
+    
+    # discover_repo_root from worktree should return main repo, not worktree path
+    repo_root = discover_repo_root(start=worktree_path)
+    assert repo_root.resolve() == real_git_repo.resolve()
+    
+    # Clean up worktree
+    subprocess.run(
+        ["git", "worktree", "remove", str(worktree_path)],
+        cwd=real_git_repo,
+        check=True,
+        capture_output=True
+    )
+
+
+def test_discover_repo_root_with_relative_default_repo_path(real_git_repo, non_git_directory):
+    """discover_repo_root() should handle relative paths in default_repo."""
+    # Change to parent directory to make real_git_repo a relative path
+    repo_parent = real_git_repo.parent
+    relative_path = real_git_repo.name
+    
+    repo_root = discover_repo_root(start=non_git_directory, default_repo=f"{repo_parent}/{relative_path}")
+    assert repo_root.resolve() == real_git_repo.resolve()
+
+
+def test_discover_repo_root_with_empty_string_default_repo(non_git_directory):
+    """discover_repo_root() should treat empty string default_repo as None."""
+    with pytest.raises(RepoDiscoveryError) as exc_info:
+        discover_repo_root(start=non_git_directory, default_repo="")
+    
+    assert "Not in a git repository" in str(exc_info.value)
+
+
+def test_discover_repo_root_with_whitespace_only_default_repo(non_git_directory):
+    """discover_repo_root() should handle whitespace-only default_repo gracefully."""
+    with pytest.raises(RepoDiscoveryError):
+        discover_repo_root(start=non_git_directory, default_repo="   ")
+
+
+def test_discover_repo_root_handles_permission_denied_gracefully(non_git_directory):
+    """discover_repo_root() should handle permission errors gracefully."""
+    import os
+    import stat
+    
+    # Create a directory we can't read
+    restricted_dir = non_git_directory / "no_access"
+    restricted_dir.mkdir()
+    
+    # Make it unreadable (on systems that support it)
+    try:
+        os.chmod(restricted_dir, 0o000)
+        
+        with pytest.raises((RepoDiscoveryError, PermissionError)):
+            discover_repo_root(start=non_git_directory, default_repo=str(restricted_dir))
+    finally:
+        # Restore permissions so cleanup works
+        try:
+            os.chmod(restricted_dir, 0o755)
+        except (OSError, PermissionError):
+            pass  # May fail on some systems, that's OK
+
+
+def test_discover_repo_root_with_special_characters_in_path(non_git_directory):
+    """discover_repo_root() should handle special characters in default_repo paths."""
+    # Test with spaces, unicode, etc.
+    special_path = non_git_directory / "repo with spaces & üñíçödé"
+    special_path.mkdir()
+    
+    # Should fail gracefully (not crash) when path exists but isn't a repo
+    with pytest.raises(RepoDiscoveryError):
+        discover_repo_root(start=non_git_directory, default_repo=str(special_path))
+
+
+def test_discover_repo_root_with_very_long_path(non_git_directory):
+    """discover_repo_root() should handle very long paths."""
+    # Create a very long path
+    long_name = "a" * 200  # Very long directory name
+    long_path = non_git_directory / long_name
+    
+    try:
+        long_path.mkdir()
+        
+        with pytest.raises(RepoDiscoveryError):
+            discover_repo_root(start=non_git_directory, default_repo=str(long_path))
+    except OSError:
+        # Path too long for filesystem - that's OK, skip this test
+        pytest.skip("Filesystem doesn't support very long paths")
+
+
+def test_discover_repo_root_with_symlink_default_repo(real_git_repo, non_git_directory):
+    """discover_repo_root() should follow symlinks in default_repo."""
+    import os
+    
+    # Create a symlink to the real repo
+    symlink_path = non_git_directory / "repo_symlink"
+    
+    try:
+        os.symlink(str(real_git_repo), str(symlink_path))
+        
+        repo_root = discover_repo_root(start=non_git_directory, default_repo=str(symlink_path))
+        # Should resolve to the real repo
+        assert repo_root.resolve() == real_git_repo.resolve()
+    except OSError:
+        # Symlinks not supported on this platform
+        pytest.skip("Symlinks not supported on this platform")
+
+
+def test_discover_repo_root_handles_broken_symlink_gracefully(non_git_directory):
+    """discover_repo_root() should handle broken symlinks gracefully."""
+    import os
+    
+    # Create a symlink to a non-existent target
+    broken_symlink = non_git_directory / "broken_link"
+    nonexistent_target = non_git_directory / "does_not_exist"
+    
+    try:
+        os.symlink(str(nonexistent_target), str(broken_symlink))
+        
+        with pytest.raises(RepoDiscoveryError):
+            discover_repo_root(start=non_git_directory, default_repo=str(broken_symlink))
+    except OSError:
+        # Symlinks not supported on this platform
+        pytest.skip("Symlinks not supported on this platform")
+
+
+def test_discover_repo_root_with_file_instead_of_directory(non_git_directory):
+    """discover_repo_root() should fail gracefully when default_repo points to a file."""
+    # Create a regular file
+    not_a_dir = non_git_directory / "just_a_file.txt"
+    not_a_dir.write_text("I'm not a directory")
+    
+    with pytest.raises((RepoDiscoveryError, NotADirectoryError)):
+        discover_repo_root(start=non_git_directory, default_repo=str(not_a_dir))
+
+
+def test_discover_repo_root_with_git_file_repo(non_git_directory):
+    """discover_repo_root() should handle git repositories with .git files (worktrees/submodules)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a main repo
+        main_repo = Path(tmpdir) / "main"
+        main_repo.mkdir()
+        subprocess.run(["git", "init"], cwd=main_repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=main_repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=main_repo, check=True, capture_output=True)
+        (main_repo / "README.md").write_text("main")
+        subprocess.run(["git", "add", "."], cwd=main_repo, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=main_repo, check=True, capture_output=True)
+        
+        # Create a worktree (which will have a .git file, not directory)
+        worktree_dir = Path(tmpdir) / "worktree"
+        subprocess.run(
+            ["git", "worktree", "add", str(worktree_dir), "-b", "feature"],
+            cwd=main_repo,
+            check=True,
+            capture_output=True
+        )
+        
+        # discover_repo_root with the worktree as default_repo should work
+        repo_root = discover_repo_root(start=non_git_directory, default_repo=str(worktree_dir))
+        assert repo_root.resolve() == main_repo.resolve()  # Should return main repo, not worktree

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,11 +1,19 @@
 """Path template tests - only the failure modes that matter."""
 
-import pytest
+import contextlib
+import os.path
+from pathlib import Path
 import subprocess
 import tempfile
-from pathlib import Path
 
-from wt.paths import build_template_context, render_path_template, discover_repo_root, RepoDiscoveryError
+import pytest
+
+from wt.paths import (
+    RepoDiscoveryError,
+    build_template_context,
+    discover_repo_root,
+    render_path_template,
+)
 
 
 def test_template_renders_all_variables(tmp_path):
@@ -71,17 +79,26 @@ def real_git_repo():
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_path = Path(tmpdir) / "test_repo"
         repo_path.mkdir()
-        
+
         # Initialize git repo
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_path, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo_path, check=True, capture_output=True)
-        
+        subprocess.run(
+            ["git", "config", "user.name", "Test"], cwd=repo_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+
         # Create initial commit
         (repo_path / "README.md").write_text("test")
         subprocess.run(["git", "add", "."], cwd=repo_path, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "initial"], cwd=repo_path, check=True, capture_output=True)
-        
+        subprocess.run(
+            ["git", "commit", "-m", "initial"], cwd=repo_path, check=True, capture_output=True
+        )
+
         yield repo_path
 
 
@@ -105,7 +122,7 @@ def test_discover_repo_root_works_from_subdirectory(real_git_repo):
     """discover_repo_root() should find repo root from subdirectories."""
     subdir = real_git_repo / "subdir" / "deep"
     subdir.mkdir(parents=True)
-    
+
     repo_root = discover_repo_root(start=subdir)
     assert repo_root.resolve() == real_git_repo.resolve()
 
@@ -114,7 +131,7 @@ def test_discover_repo_root_fails_without_default_repo(non_git_directory):
     """discover_repo_root() should fail when not in git repo and no default_repo."""
     with pytest.raises(RepoDiscoveryError) as exc_info:
         discover_repo_root(start=non_git_directory)
-    
+
     assert "Not in a git repository" in str(exc_info.value)
 
 
@@ -131,27 +148,34 @@ def test_discover_repo_root_expands_tilde_in_default_repo(real_git_repo, non_git
     fake_home.mkdir()
     home_repo = fake_home / "repo"
     home_repo.mkdir()
-    
+
     # Initialize git repo in fake home
     subprocess.run(["git", "init"], cwd=home_repo, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=home_repo, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=home_repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=home_repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=home_repo,
+        check=True,
+        capture_output=True,
+    )
     (home_repo / "README.md").write_text("test")
     subprocess.run(["git", "add", "."], cwd=home_repo, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "initial"], cwd=home_repo, check=True, capture_output=True)
-    
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=home_repo, check=True, capture_output=True
+    )
+
     # Mock os.path.expanduser to return our fake home
-    import os
-    import os.path
     original_expanduser = os.path.expanduser
-    
+
     def mock_expanduser(path):
         if path.startswith("~"):
             return path.replace("~", str(fake_home), 1)
         return original_expanduser(path)
-    
+
     os.path.expanduser = mock_expanduser
-    
+
     try:
         repo_root = discover_repo_root(start=non_git_directory, default_repo="~/repo")
         assert repo_root.resolve() == home_repo.resolve()
@@ -163,10 +187,10 @@ def test_discover_repo_root_fails_with_invalid_default_repo(non_git_directory):
     """discover_repo_root() should fail when default_repo is not a git repository."""
     invalid_path = non_git_directory / "not_a_git_repo"
     invalid_path.mkdir()
-    
+
     with pytest.raises(RepoDiscoveryError) as exc_info:
         discover_repo_root(start=non_git_directory, default_repo=str(invalid_path))
-    
+
     assert "Default repository" in str(exc_info.value)
     assert "not a valid git repository" in str(exc_info.value)
 
@@ -174,10 +198,10 @@ def test_discover_repo_root_fails_with_invalid_default_repo(non_git_directory):
 def test_discover_repo_root_fails_with_nonexistent_default_repo(non_git_directory):
     """discover_repo_root() should fail when default_repo doesn't exist."""
     nonexistent_path = non_git_directory / "does_not_exist"
-    
+
     with pytest.raises(RepoDiscoveryError) as exc_info:
         discover_repo_root(start=non_git_directory, default_repo=str(nonexistent_path))
-    
+
     assert "Default repository" in str(exc_info.value)
     assert "not a valid git repository" in str(exc_info.value)
 
@@ -189,9 +213,19 @@ def test_discover_repo_root_prefers_current_repo_over_default(real_git_repo):
         default_repo = Path(tmpdir) / "default"
         default_repo.mkdir()
         subprocess.run(["git", "init"], cwd=default_repo, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test"], cwd=default_repo, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=default_repo, check=True, capture_output=True)
-        
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=default_repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=default_repo,
+            check=True,
+            capture_output=True,
+        )
+
         # Should return the current repo, not the default
         repo_root = discover_repo_root(start=real_git_repo, default_repo=str(default_repo))
         assert repo_root.resolve() == real_git_repo.resolve()
@@ -203,24 +237,24 @@ def test_discover_repo_root_handles_worktree_correctly(real_git_repo):
     worktrees_dir = real_git_repo.parent / "worktrees"
     worktrees_dir.mkdir()
     worktree_path = worktrees_dir / "feature-branch"
-    
+
     subprocess.run(
         ["git", "worktree", "add", str(worktree_path), "-b", "feature-branch"],
         cwd=real_git_repo,
         check=True,
-        capture_output=True
+        capture_output=True,
     )
-    
+
     # discover_repo_root from worktree should return main repo, not worktree path
     repo_root = discover_repo_root(start=worktree_path)
     assert repo_root.resolve() == real_git_repo.resolve()
-    
+
     # Clean up worktree
     subprocess.run(
         ["git", "worktree", "remove", str(worktree_path)],
         cwd=real_git_repo,
         check=True,
-        capture_output=True
+        capture_output=True,
     )
 
 
@@ -229,8 +263,10 @@ def test_discover_repo_root_with_relative_default_repo_path(real_git_repo, non_g
     # Change to parent directory to make real_git_repo a relative path
     repo_parent = real_git_repo.parent
     relative_path = real_git_repo.name
-    
-    repo_root = discover_repo_root(start=non_git_directory, default_repo=f"{repo_parent}/{relative_path}")
+
+    repo_root = discover_repo_root(
+        start=non_git_directory, default_repo=f"{repo_parent}/{relative_path}"
+    )
     assert repo_root.resolve() == real_git_repo.resolve()
 
 
@@ -238,7 +274,7 @@ def test_discover_repo_root_with_empty_string_default_repo(non_git_directory):
     """discover_repo_root() should treat empty string default_repo as None."""
     with pytest.raises(RepoDiscoveryError) as exc_info:
         discover_repo_root(start=non_git_directory, default_repo="")
-    
+
     assert "Not in a git repository" in str(exc_info.value)
 
 
@@ -250,25 +286,20 @@ def test_discover_repo_root_with_whitespace_only_default_repo(non_git_directory)
 
 def test_discover_repo_root_handles_permission_denied_gracefully(non_git_directory):
     """discover_repo_root() should handle permission errors gracefully."""
-    import os
-    import stat
-    
     # Create a directory we can't read
     restricted_dir = non_git_directory / "no_access"
     restricted_dir.mkdir()
-    
+
     # Make it unreadable (on systems that support it)
     try:
-        os.chmod(restricted_dir, 0o000)
-        
+        restricted_dir.chmod(0o000)
+
         with pytest.raises((RepoDiscoveryError, PermissionError)):
             discover_repo_root(start=non_git_directory, default_repo=str(restricted_dir))
     finally:
         # Restore permissions so cleanup works
-        try:
-            os.chmod(restricted_dir, 0o755)
-        except (OSError, PermissionError):
-            pass  # May fail on some systems, that's OK
+        with contextlib.suppress(OSError, PermissionError):
+            restricted_dir.chmod(0o755)
 
 
 def test_discover_repo_root_with_special_characters_in_path(non_git_directory):
@@ -276,7 +307,7 @@ def test_discover_repo_root_with_special_characters_in_path(non_git_directory):
     # Test with spaces, unicode, etc.
     special_path = non_git_directory / "repo with spaces & üñíçödé"
     special_path.mkdir()
-    
+
     # Should fail gracefully (not crash) when path exists but isn't a repo
     with pytest.raises(RepoDiscoveryError):
         discover_repo_root(start=non_git_directory, default_repo=str(special_path))
@@ -287,10 +318,10 @@ def test_discover_repo_root_with_very_long_path(non_git_directory):
     # Create a very long path
     long_name = "a" * 200  # Very long directory name
     long_path = non_git_directory / long_name
-    
+
     try:
         long_path.mkdir()
-        
+
         with pytest.raises(RepoDiscoveryError):
             discover_repo_root(start=non_git_directory, default_repo=str(long_path))
     except OSError:
@@ -300,14 +331,12 @@ def test_discover_repo_root_with_very_long_path(non_git_directory):
 
 def test_discover_repo_root_with_symlink_default_repo(real_git_repo, non_git_directory):
     """discover_repo_root() should follow symlinks in default_repo."""
-    import os
-    
     # Create a symlink to the real repo
     symlink_path = non_git_directory / "repo_symlink"
-    
+
     try:
-        os.symlink(str(real_git_repo), str(symlink_path))
-        
+        symlink_path.symlink_to(real_git_repo)
+
         repo_root = discover_repo_root(start=non_git_directory, default_repo=str(symlink_path))
         # Should resolve to the real repo
         assert repo_root.resolve() == real_git_repo.resolve()
@@ -318,15 +347,13 @@ def test_discover_repo_root_with_symlink_default_repo(real_git_repo, non_git_dir
 
 def test_discover_repo_root_handles_broken_symlink_gracefully(non_git_directory):
     """discover_repo_root() should handle broken symlinks gracefully."""
-    import os
-    
     # Create a symlink to a non-existent target
     broken_symlink = non_git_directory / "broken_link"
     nonexistent_target = non_git_directory / "does_not_exist"
-    
+
     try:
-        os.symlink(str(nonexistent_target), str(broken_symlink))
-        
+        broken_symlink.symlink_to(nonexistent_target)
+
         with pytest.raises(RepoDiscoveryError):
             discover_repo_root(start=non_git_directory, default_repo=str(broken_symlink))
     except OSError:
@@ -339,7 +366,7 @@ def test_discover_repo_root_with_file_instead_of_directory(non_git_directory):
     # Create a regular file
     not_a_dir = non_git_directory / "just_a_file.txt"
     not_a_dir.write_text("I'm not a directory")
-    
+
     with pytest.raises((RepoDiscoveryError, NotADirectoryError)):
         discover_repo_root(start=non_git_directory, default_repo=str(not_a_dir))
 
@@ -351,21 +378,30 @@ def test_discover_repo_root_with_git_file_repo(non_git_directory):
         main_repo = Path(tmpdir) / "main"
         main_repo.mkdir()
         subprocess.run(["git", "init"], cwd=main_repo, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test"], cwd=main_repo, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=main_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test"], cwd=main_repo, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=main_repo,
+            check=True,
+            capture_output=True,
+        )
         (main_repo / "README.md").write_text("main")
         subprocess.run(["git", "add", "."], cwd=main_repo, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "initial"], cwd=main_repo, check=True, capture_output=True)
-        
+        subprocess.run(
+            ["git", "commit", "-m", "initial"], cwd=main_repo, check=True, capture_output=True
+        )
+
         # Create a worktree (which will have a .git file, not directory)
         worktree_dir = Path(tmpdir) / "worktree"
         subprocess.run(
             ["git", "worktree", "add", str(worktree_dir), "-b", "feature"],
             cwd=main_repo,
             check=True,
-            capture_output=True
+            capture_output=True,
         )
-        
+
         # discover_repo_root with the worktree as default_repo should work
         repo_root = discover_repo_root(start=non_git_directory, default_repo=str(worktree_dir))
         assert repo_root.resolve() == main_repo.resolve()  # Should return main repo, not worktree

--- a/uv.lock
+++ b/uv.lock
@@ -213,7 +213,6 @@ wheels = [
 
 [[package]]
 name = "wt-cli"
-version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -189,6 +189,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shtab"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/3e/837067b970c1d2ffa936c72f384a63fdec4e186b74da781e921354a94024/shtab-1.7.2.tar.gz", hash = "sha256:8c16673ade76a2d42417f03e57acf239bfb5968e842204c17990cae357d07d6f", size = 45751, upload-time = "2025-04-12T20:28:03.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/03/3271b7bb470fbab4adf5bd30b0d32143909d96f3608d815b447357f47f2b/shtab-1.7.2-py3-none-any.whl", hash = "sha256:858a5805f6c137bb0cda4f282d27d08fd44ca487ab4a6a36d2a400263cd0b5c1", size = 14214, upload-time = "2025-04-12T20:28:01.82Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.34.0"
 source = { registry = "https://pypi.org/simple" }
@@ -211,6 +220,7 @@ source = { editable = "." }
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "shtab" },
 ]
 
 [package.metadata]
@@ -219,4 +229,5 @@ dev = [
 dev = [
     { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=7.0.0" },
+    { name = "shtab", specifier = ">=1.6.0" },
 ]

--- a/wt/cli.py
+++ b/wt/cli.py
@@ -8,6 +8,36 @@ import sys
 
 from . import config, gitutil, hooks, lock, paths, status, table
 
+try:
+    import shtab
+    SHTAB_AVAILABLE = True
+except ImportError:
+    SHTAB_AVAILABLE = False
+
+
+def _complete_worktree_names():
+    """Get worktree names for shell completion."""
+    try:
+        repo_root = paths.discover_repo_root()
+        worktrees = gitutil.list_worktrees(repo_root)
+        # Extract branch names from worktree info
+        branch_names = []
+        for wt_info in worktrees:
+            if wt_info.get("branch") and wt_info["branch"] != "(detached HEAD)":
+                # Remove origin/ prefix if present
+                branch = wt_info["branch"]
+                if branch.startswith("origin/"):
+                    branch = branch[7:]
+                branch_names.append(branch)
+        return branch_names
+    except Exception:
+        # If anything goes wrong, return empty list
+        return []
+
+
+# Custom completion pattern for shtab
+_WORKTREE_COMPLETION = {"bash": "_shtab_complete_worktrees", "zsh": "_shtab_complete_worktrees", "tcsh": "C"}
+
 
 def cmd_new(args, cfg, repo_root):  # noqa: PLR0912, PLR0915
     """Create a new worktree."""
@@ -579,6 +609,146 @@ def cmd_hooks_list(_args, cfg, repo_root):
             print(f"  chmod +x {hook}")
 
 
+def cmd_completion(args, _cfg, _repo_root):
+    """Generate shell completion scripts."""
+    if not SHTAB_AVAILABLE:
+        print("Error: shtab is required to generate completions", file=sys.stderr)
+        print("Install with: pip install shtab", file=sys.stderr)
+        sys.exit(1)
+
+    # Create a parser with the same structure as main()
+    parser = argparse.ArgumentParser(
+        description="wt - Zero-friction git worktree manager",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--repo", type=Path, help="Repository path (default: auto-discover)")
+    parser.add_argument("--config", type=Path, help="Config file override")
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # new
+    parser_new = subparsers.add_parser("new", help="Create a new worktree")
+    parser_new.add_argument("branch", help="Branch name")
+    parser_new.add_argument(
+        "--from", dest="from_branch", default=None, help="Source branch (default: from config)"
+    )
+    parser_new.add_argument("--track", action="store_true", help="Set upstream tracking")
+    parser_new.add_argument("--force", action="store_true", help="Force creation, remove empty dir")
+
+    # list
+    parser_list = subparsers.add_parser("list", help="List all worktrees")
+    parser_list.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # status
+    parser_status = subparsers.add_parser("status", help="Show worktree status")
+    parser_status.add_argument("--json", action="store_true", help="Output as JSON")
+    parser_status.add_argument("--rich", action="store_true", default=None, help="Use rich formatting")
+
+    # rm
+    parser_rm = subparsers.add_parser("rm", help="Remove a worktree")
+    rm_branch_arg = parser_rm.add_argument("branch", help="Branch name")
+    rm_branch_arg.complete = _WORKTREE_COMPLETION
+    parser_rm.add_argument("--yes", action="store_true", help="Skip confirmation")
+    parser_rm.add_argument("--delete-branch", action="store_true", help="Also delete the branch")
+    parser_rm.add_argument("--force", action="store_true", help="Force deletion")
+
+    # prune-merged
+    parser_prune = subparsers.add_parser("prune-merged", help="Prune merged branches")
+    parser_prune.add_argument("--base", help="Base branch (default: from config)")
+    parser_prune.add_argument("--protected", nargs="*", help="Protected branches (default: from config)")
+    parser_prune.add_argument("--yes", action="store_true", help="Skip confirmation")
+    parser_prune.add_argument("--delete-branch", action="store_true", help="Also delete branches")
+
+    # pull-main
+    parser_pull = subparsers.add_parser("pull-main", help="Update all worktrees from main")
+    parser_pull.add_argument("--base", help="Base branch (default: from config)")
+    parser_pull.add_argument("--strategy", choices=["rebase", "merge", "ff-only"], help="Update strategy")
+    parser_pull.add_argument("--stash", action="store_true", help="Auto-stash dirty trees")
+
+    # where
+    parser_where = subparsers.add_parser("where", help="Print worktree path")
+    where_branch_arg = parser_where.add_argument("branch", help="Branch name")
+    where_branch_arg.complete = _WORKTREE_COMPLETION
+
+    # open
+    parser_open = subparsers.add_parser("open", help="Print worktree path (alias for where)")
+    open_branch_arg = parser_open.add_argument("branch", help="Branch name")
+    open_branch_arg.complete = _WORKTREE_COMPLETION
+
+    # gc
+    subparsers.add_parser("gc", help="Clean up stale worktrees")
+
+    # doctor
+    subparsers.add_parser("doctor", help="Check configuration")
+
+    # completion
+    parser_completion = subparsers.add_parser("completion", help="Generate shell completions")
+    parser_completion.add_argument("shell", choices=["bash", "zsh", "tcsh"], help="Shell type")
+
+    # hooks
+    parser_hooks = subparsers.add_parser("hooks", help="Manage hooks")
+    hooks_subparsers = parser_hooks.add_subparsers(dest="hooks_command", help="Hooks command")
+
+    # hooks init
+    parser_hooks_init = hooks_subparsers.add_parser("init", help="Initialize hooks directory")
+    parser_hooks_init.add_argument("--local", action="store_true", help="Create local hooks directory")
+    parser_hooks_init.add_argument("--template", action="store_true", help="Create example template hook")
+    parser_hooks_init.add_argument("--force", action="store_true", help="Overwrite existing template")
+
+    # hooks list
+    hooks_subparsers.add_parser("list", help="List all hooks and their status")
+
+    # Generate and print completion script
+    # Define custom choice functions for shtab
+    choice_functions = {
+        "_shtab_complete_worktrees": _complete_worktree_names,
+    }
+    
+    completion_script = shtab.complete(parser, shell=args.shell, choice_functions=choice_functions)
+    
+    # Add custom completion functions for different shells
+    if args.shell == "bash":
+        custom_function = """
+_shtab_complete_worktrees() {
+    local python_script="
+import sys; sys.path.insert(0, '.')
+try:
+    from wt.cli import _complete_worktree_names
+    branches = _complete_worktree_names()
+    print(' '.join(branches))
+except:
+    pass
+"
+    local branches=$(python3 -c "$python_script" 2>/dev/null)
+    COMPREPLY=($(compgen -W "$branches" -- "$2"))
+}
+
+"""
+        completion_script = custom_function + completion_script
+    elif args.shell == "zsh":
+        custom_function = """
+_shtab_complete_worktrees() {
+    local python_script="
+import sys; sys.path.insert(0, '.')
+try:
+    from wt.cli import _complete_worktree_names
+    branches = _complete_worktree_names()
+    for branch in branches:
+        print(branch)
+except:
+    pass
+"
+    local branches=($(python3 -c "$python_script" 2>/dev/null))
+    _describe 'worktree branches' branches
+}
+
+"""
+        completion_script = custom_function + completion_script
+    
+    print(completion_script)
+
+
 def cmd_doctor(_args, cfg, repo_root):  # noqa: PLR0912
     """Check configuration and environment."""
     print("Checking wt configuration and environment...\n")
@@ -752,6 +922,11 @@ def main():  # noqa: PLR0915, PLR0912
     # doctor
     subparsers.add_parser("doctor", help="Check configuration")
 
+    # completion
+    if SHTAB_AVAILABLE:
+        parser_completion = subparsers.add_parser("completion", help="Generate shell completions")
+        parser_completion.add_argument("shell", choices=["bash", "zsh", "tcsh"], help="Shell type")
+
     # hooks
     parser_hooks = subparsers.add_parser("hooks", help="Manage hooks")
     hooks_subparsers = parser_hooks.add_subparsers(dest="hooks_command", help="Hooks command")
@@ -816,6 +991,8 @@ def main():  # noqa: PLR0915, PLR0912
             cmd_gc(args, cfg, repo_root)
         elif args.command == "doctor":
             cmd_doctor(args, cfg, repo_root)
+        elif args.command == "completion":
+            cmd_completion(args, cfg, repo_root)
         elif args.command == "hooks":
             if args.hooks_command == "init":
                 cmd_hooks_init(args, cfg, repo_root)

--- a/wt/cli.py
+++ b/wt/cli.py
@@ -18,14 +18,17 @@ except ImportError:
 def _complete_worktree_names():
     """Get worktree names for shell completion."""
     try:
-        repo_root = paths.discover_repo_root()
+        # Try to discover repo, with fallback to default_repo if configured
+        minimal_cfg = config.load_config(repo_root=None)
+        default_repo = minimal_cfg["paths"]["default_repo"] or None
+        repo_root = paths.discover_repo_root(default_repo=default_repo)
         worktrees = gitutil.list_worktrees(repo_root)
         # Extract branch names from worktree info
         branch_names = []
         for wt_info in worktrees:
-            if wt_info.get("branch") and wt_info["branch"] != "(detached HEAD)":
+            if wt_info.branch and wt_info.branch != "(detached HEAD)":
                 # Remove origin/ prefix if present
-                branch = wt_info["branch"]
+                branch = wt_info.branch
                 if branch.startswith("origin/"):
                     branch = branch[7:]
                 branch_names.append(branch)
@@ -956,16 +959,24 @@ def main():  # noqa: PLR0915, PLR0912
     if args.verbose:
         gitutil.set_verbose(True)
 
+    # Load minimal config to get default_repo setting for discovery
+    # (we load full config again after repo discovery)
+    minimal_cfg = config.load_config(repo_root=None)
+    default_repo = minimal_cfg["paths"]["default_repo"] or None
+
     # Discover repo root (except for doctor which handles errors)
     try:
-        repo_root = paths.discover_repo_root(args.repo) if args.repo else paths.discover_repo_root()
+        if args.repo:
+            repo_root = paths.discover_repo_root(args.repo)
+        else:
+            repo_root = paths.discover_repo_root(default_repo=default_repo)
     except paths.RepoDiscoveryError as e:
         if args.command != "doctor":
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
         repo_root = Path.cwd()  # For doctor, use cwd
 
-    # Load config
+    # Load full config with discovered repo_root
     cfg = config.load_config(repo_root)
 
     # Acquire lock

--- a/wt/cli.py
+++ b/wt/cli.py
@@ -8,8 +8,10 @@ import sys
 
 from . import config, gitutil, hooks, lock, paths, status, table
 
+
 try:
     import shtab
+
     SHTAB_AVAILABLE = True
 except ImportError:
     SHTAB_AVAILABLE = False
@@ -32,14 +34,19 @@ def _complete_worktree_names():
                 if branch.startswith("origin/"):
                     branch = branch[7:]
                 branch_names.append(branch)
-        return branch_names
     except Exception:
         # If anything goes wrong, return empty list
         return []
+    else:
+        return branch_names
 
 
 # Custom completion pattern for shtab
-_WORKTREE_COMPLETION = {"bash": "_shtab_complete_worktrees", "zsh": "_shtab_complete_worktrees", "tcsh": "C"}
+_WORKTREE_COMPLETION = {
+    "bash": "_shtab_complete_worktrees",
+    "zsh": "_shtab_complete_worktrees",
+    "tcsh": "C",
+}
 
 
 def cmd_new(args, cfg, repo_root):  # noqa: PLR0912, PLR0915
@@ -646,7 +653,9 @@ def cmd_completion(args, _cfg, _repo_root):
     # status
     parser_status = subparsers.add_parser("status", help="Show worktree status")
     parser_status.add_argument("--json", action="store_true", help="Output as JSON")
-    parser_status.add_argument("--rich", action="store_true", default=None, help="Use rich formatting")
+    parser_status.add_argument(
+        "--rich", action="store_true", default=None, help="Use rich formatting"
+    )
 
     # rm
     parser_rm = subparsers.add_parser("rm", help="Remove a worktree")
@@ -659,14 +668,18 @@ def cmd_completion(args, _cfg, _repo_root):
     # prune-merged
     parser_prune = subparsers.add_parser("prune-merged", help="Prune merged branches")
     parser_prune.add_argument("--base", help="Base branch (default: from config)")
-    parser_prune.add_argument("--protected", nargs="*", help="Protected branches (default: from config)")
+    parser_prune.add_argument(
+        "--protected", nargs="*", help="Protected branches (default: from config)"
+    )
     parser_prune.add_argument("--yes", action="store_true", help="Skip confirmation")
     parser_prune.add_argument("--delete-branch", action="store_true", help="Also delete branches")
 
     # pull-main
     parser_pull = subparsers.add_parser("pull-main", help="Update all worktrees from main")
     parser_pull.add_argument("--base", help="Base branch (default: from config)")
-    parser_pull.add_argument("--strategy", choices=["rebase", "merge", "ff-only"], help="Update strategy")
+    parser_pull.add_argument(
+        "--strategy", choices=["rebase", "merge", "ff-only"], help="Update strategy"
+    )
     parser_pull.add_argument("--stash", action="store_true", help="Auto-stash dirty trees")
 
     # where
@@ -695,9 +708,15 @@ def cmd_completion(args, _cfg, _repo_root):
 
     # hooks init
     parser_hooks_init = hooks_subparsers.add_parser("init", help="Initialize hooks directory")
-    parser_hooks_init.add_argument("--local", action="store_true", help="Create local hooks directory")
-    parser_hooks_init.add_argument("--template", action="store_true", help="Create example template hook")
-    parser_hooks_init.add_argument("--force", action="store_true", help="Overwrite existing template")
+    parser_hooks_init.add_argument(
+        "--local", action="store_true", help="Create local hooks directory"
+    )
+    parser_hooks_init.add_argument(
+        "--template", action="store_true", help="Create example template hook"
+    )
+    parser_hooks_init.add_argument(
+        "--force", action="store_true", help="Overwrite existing template"
+    )
 
     # hooks list
     hooks_subparsers.add_parser("list", help="List all hooks and their status")
@@ -707,9 +726,9 @@ def cmd_completion(args, _cfg, _repo_root):
     choice_functions = {
         "_shtab_complete_worktrees": _complete_worktree_names,
     }
-    
+
     completion_script = shtab.complete(parser, shell=args.shell, choice_functions=choice_functions)
-    
+
     # Add custom completion functions for different shells
     if args.shell == "bash":
         custom_function = """
@@ -748,7 +767,7 @@ except:
 
 """
         completion_script = custom_function + completion_script
-    
+
     print(completion_script)
 
 

--- a/wt/config.py
+++ b/wt/config.py
@@ -11,6 +11,7 @@ def get_default_config() -> dict[str, Any]:
         "paths": {
             "worktree_root": "",
             "worktree_path_template": "$WT_ROOT/$BRANCH_NAME",
+            "default_repo": "",
         },
         "branches": {
             "auto_prefix": "",

--- a/wt/lock.py
+++ b/wt/lock.py
@@ -5,7 +5,14 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 from typing import TextIO
+
+
+if sys.platform != "win32":
+    import fcntl
+else:
+    import ctypes
 
 
 class LockError(Exception):
@@ -93,8 +100,6 @@ class RepoLock:
 
     def _acquire_unix(self) -> None:
         """Acquire lock using fcntl (Unix)."""
-        import fcntl
-
         try:
             fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except OSError as e:
@@ -104,8 +109,6 @@ class RepoLock:
 
     def _acquire_windows(self) -> None:
         """Acquire lock using PID file (Windows)."""
-        import time
-
         # Simple PID-based locking for Windows
         pid = os.getpid()
         max_attempts = 50  # 5 seconds with 100ms sleep
@@ -140,8 +143,6 @@ class RepoLock:
 
     def _process_exists_windows(self, pid: int) -> bool:
         """Check if process exists on Windows."""
-        import ctypes
-
         process_query_information = 0x0400
         handle = ctypes.windll.kernel32.OpenProcess(process_query_information, False, pid)
         if handle:
@@ -156,8 +157,6 @@ class RepoLock:
 
         # Release lock
         if sys.platform != "win32":
-            import fcntl
-
             with contextlib.suppress(OSError):
                 fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_UN)
 

--- a/wt/paths.py
+++ b/wt/paths.py
@@ -9,19 +9,22 @@ class RepoDiscoveryError(Exception):
     """Raised when repository discovery fails."""
 
 
-def discover_repo_root(start: Path | None = None) -> Path:
+def discover_repo_root(start: Path | None = None, default_repo: str | None = None) -> Path:
     """Discover the main git repository root (not worktree root).
 
     When run from a worktree, this returns the main repo root, not the worktree path.
+    If not in a git repository and default_repo is provided, validates and returns
+    the default repository path.
 
     Args:
         start: Starting directory (defaults to current working directory)
+        default_repo: Fallback repository path when not in a git directory
 
     Returns:
         Path to main repository root
 
     Raises:
-        RepoDiscoveryError: If not in a git repository
+        RepoDiscoveryError: If not in a git repository and no valid default_repo provided
 
     """
     try:
@@ -50,12 +53,33 @@ def discover_repo_root(start: Path | None = None) -> Path:
         # The parent of the common git directory is the main repo root
         # In a regular repo: .git -> repo_root
         # In a worktree: /path/to/main/repo/.git -> main repo_root
+        return git_common_dir.parent
     except subprocess.CalledProcessError as e:
+        # Not in a git repository - try default_repo fallback
+        if default_repo:
+            default_path = Path(default_repo).expanduser().resolve()
+            
+            # Validate that default_repo is actually a git repository
+            try:
+                result = subprocess.run(
+                    ["git", "rev-parse", "--git-common-dir"],
+                    cwd=default_path,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                git_common_dir = Path(result.stdout.strip())
+                if not git_common_dir.is_absolute():
+                    git_common_dir = (default_path / git_common_dir).resolve()
+                return git_common_dir.parent
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                raise RepoDiscoveryError(
+                    f"Default repository '{default_repo}' is not a valid git repository"
+                ) from e
+        
         raise RepoDiscoveryError(f"Not in a git repository: {e.stderr.strip()}") from e
     except FileNotFoundError as e:
         raise RepoDiscoveryError("git command not found") from e
-    else:
-        return git_common_dir.parent
 
 
 def default_wt_root(repo_root: Path) -> Path:

--- a/wt/paths.py
+++ b/wt/paths.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from pathlib import Path
+import re
 import subprocess
 
 
@@ -53,33 +54,34 @@ def discover_repo_root(start: Path | None = None, default_repo: str | None = Non
         # The parent of the common git directory is the main repo root
         # In a regular repo: .git -> repo_root
         # In a worktree: /path/to/main/repo/.git -> main repo_root
-        return git_common_dir.parent
     except subprocess.CalledProcessError as e:
         # Not in a git repository - try default_repo fallback
-        if default_repo:
-            default_path = Path(default_repo).expanduser().resolve()
-            
-            # Validate that default_repo is actually a git repository
-            try:
-                result = subprocess.run(
-                    ["git", "rev-parse", "--git-common-dir"],
-                    cwd=default_path,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                git_common_dir = Path(result.stdout.strip())
-                if not git_common_dir.is_absolute():
-                    git_common_dir = (default_path / git_common_dir).resolve()
-                return git_common_dir.parent
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                raise RepoDiscoveryError(
-                    f"Default repository '{default_repo}' is not a valid git repository"
-                ) from e
-        
-        raise RepoDiscoveryError(f"Not in a git repository: {e.stderr.strip()}") from e
+        if not default_repo:
+            raise RepoDiscoveryError(f"Not in a git repository: {e.stderr.strip()}") from e
+        default_path = Path(default_repo).expanduser().resolve()
+
+        # Validate that default_repo is actually a git repository
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--git-common-dir"],
+                cwd=default_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            git_common_dir = Path(result.stdout.strip())
+            if not git_common_dir.is_absolute():
+                git_common_dir = (default_path / git_common_dir).resolve()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            raise RepoDiscoveryError(
+                f"Default repository '{default_repo}' is not a valid git repository"
+            ) from e
+        else:
+            return git_common_dir.parent
     except FileNotFoundError as e:
         raise RepoDiscoveryError("git command not found") from e
+    else:
+        return git_common_dir.parent
 
 
 def default_wt_root(repo_root: Path) -> Path:
@@ -121,8 +123,6 @@ def render_path_template(
     result = template
 
     # Find all $VARNAME patterns
-    import re
-
     pattern = re.compile(r"\$([A-Z_][A-Z0-9_]*)")
 
     def replace_var(match):

--- a/wt/status.py
+++ b/wt/status.py
@@ -42,6 +42,7 @@ def get_worktree_status(
     is_dirty = gitutil.is_dirty(path)
 
     # Get ahead/behind upstream
+
     behind, ahead = gitutil.count_ahead_behind(path)
 
     # Get behind main

--- a/wt/table.py
+++ b/wt/table.py
@@ -1,5 +1,6 @@
 """Simple table formatting using stdlib only."""
 
+import re
 import sys
 from typing import Any
 
@@ -76,8 +77,6 @@ def format_table(headers: list[str], rows: list[list[Any]], _rich: bool = False)
 
 def _visible_len(text: str) -> int:
     """Calculate visible length of text, excluding ANSI codes."""
-    import re
-
     # Remove ANSI escape sequences
     ansi_escape = re.compile(r"\033\[[0-9;]*m")
     return len(ansi_escape.sub("", text))


### PR DESCRIPTION
I added basic completion for rm/where/open; and, the ability to set a default repository, so wt outside of git repositories will use that default, if set. My use case is because I work 90% of the time in a single repo, so this way I dont have to think about where I am in the shell. 