### PR TITLE
refactor: pass base directories instead of config paths to hook discovery

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -239,13 +239,13 @@ def test_new_worktree_with_existing_branch_not_detached(git_repo):
     )
 
     # Should NOT say "Not currently on any branch" (detached)
-    assert (
-        "Not currently on any branch" not in status_result.stdout
-    ), "Worktree is detached HEAD, should be on existing-branch"
+    assert "Not currently on any branch" not in status_result.stdout, (
+        "Worktree is detached HEAD, should be on existing-branch"
+    )
     # The branch name might have a prefix from config, so just check it contains "existing-branch"
-    assert (
-        "existing-branch" in status_result.stdout
-    ), f"Worktree should be on existing-branch, got: {status_result.stdout}"
+    assert "existing-branch" in status_result.stdout, (
+        f"Worktree should be on existing-branch, got: {status_result.stdout}"
+    )
 
 
 def test_new_from_current_moves_branch_to_worktree(git_repo):

--- a/wt/cli.py
+++ b/wt/cli.py
@@ -153,12 +153,16 @@ def cmd_new(args, cfg, repo_root):  # noqa: PLR0912, PLR0915
     local_config_path = config.get_local_config_path(repo_root)
     global_config_path = config.get_global_config_path()
 
+    # Get base directories for hook discovery
+    local_wt_dir = local_config_path.parent if local_config_path.parent.exists() else None
+    global_config_dir = global_config_path.parent
+
     try:
         hooks.run_post_create_hooks(
             worktree_path,
             context,
-            local_config_path if local_config_path.exists() else None,
-            global_config_path,
+            local_wt_dir,
+            global_config_dir,
             cfg,
         )
     except hooks.HookError as e:
@@ -511,20 +515,24 @@ def cmd_hooks_list(_args, cfg, repo_root):
     local_config_path = config.get_local_config_path(repo_root)
     global_config_path = config.get_global_config_path()
 
-    # Determine hook directories
-    local_hook_dir = local_config_path.parent / hook_dir_name
-    global_hook_dir = global_config_path.parent / hook_dir_name
+    # Get base directories for hook discovery
+    local_wt_dir = local_config_path.parent if local_config_path.parent.exists() else None
+    global_config_dir = global_config_path.parent
 
-    # Get all hooks (always pass local_config_path, hooks can exist without config file)
+    # Determine hook directories
+    local_hook_dir = local_wt_dir / hook_dir_name if local_wt_dir else None
+    global_hook_dir = global_config_dir / hook_dir_name
+
+    # Get all hooks
     executable_hooks = hooks.discover_hooks(
-        local_config_path,
-        global_config_path,
+        local_wt_dir,
+        global_config_dir,
         hook_dir_name,
     )
 
     non_executable_hooks = hooks.find_non_executable_hooks(
-        local_config_path,
-        global_config_path,
+        local_wt_dir,
+        global_config_dir,
         hook_dir_name,
     )
 
@@ -629,14 +637,16 @@ def cmd_doctor(_args, cfg, repo_root):  # noqa: PLR0912
     # Check hooks
     hook_dir = cfg["hooks"]["post_create_dir"]
 
-    all_hooks = hooks.discover_hooks(
-        local_config if local_config.exists() else None, global_config, hook_dir
-    )
+    # Get base directories for hook discovery
+    local_wt_dir = local_config.parent if local_config.parent.exists() else None
+    global_config_dir = global_config.parent
+
+    all_hooks = hooks.discover_hooks(local_wt_dir, global_config_dir, hook_dir)
 
     if all_hooks:
         # Count local vs global by checking paths
-        local_hook_dir = local_config.parent / hook_dir if local_config.exists() else None
-        global_hook_dir = global_config.parent / hook_dir
+        local_hook_dir = local_wt_dir / hook_dir if local_wt_dir else None
+        global_hook_dir = global_config_dir / hook_dir
 
         local_count = sum(
             1 for h in all_hooks if local_hook_dir and h.is_relative_to(local_hook_dir)

--- a/wt/hooks.py
+++ b/wt/hooks.py
@@ -10,15 +10,15 @@ class HookError(Exception):
 
 
 def discover_hooks(
-    local_config_path: Path | None,
-    global_config_path: Path,
+    local_base_dir: Path | None,
+    global_base_dir: Path,
     hook_dir_name: str,
 ) -> list[Path]:
     """Discover hook scripts in local and global directories.
 
     Args:
-        local_config_path: Path to local config file (or None)
-        global_config_path: Path to global config file
+        local_base_dir: Path to local .wt directory (or None if not present)
+        global_base_dir: Path to global config directory (~/.config/wt)
         hook_dir_name: Hook directory name (e.g., "hooks/post_create.d")
 
     Returns:
@@ -27,14 +27,14 @@ def discover_hooks(
     """
     hooks = []
 
-    # Local hooks (check directory exists, not just config file)
-    if local_config_path:
-        local_hook_dir = local_config_path.parent / hook_dir_name
+    # Local hooks
+    if local_base_dir:
+        local_hook_dir = local_base_dir / hook_dir_name
         if local_hook_dir.exists() and local_hook_dir.is_dir():
             hooks.extend(_collect_executable_hooks(local_hook_dir))
 
     # Global hooks
-    global_hook_dir = global_config_path.parent / hook_dir_name
+    global_hook_dir = global_base_dir / hook_dir_name
     if global_hook_dir.exists() and global_hook_dir.is_dir():
         hooks.extend(_collect_executable_hooks(global_hook_dir))
 
@@ -61,15 +61,15 @@ def _collect_executable_hooks(directory: Path) -> list[Path]:
 
 
 def find_non_executable_hooks(
-    local_config_path: Path | None,
-    global_config_path: Path,
+    local_base_dir: Path | None,
+    global_base_dir: Path,
     hook_dir_name: str,
 ) -> list[Path]:
     """Find hook files that exist but are not executable.
 
     Args:
-        local_config_path: Path to local config file (or None)
-        global_config_path: Path to global config file
+        local_base_dir: Path to local .wt directory (or None if not present)
+        global_base_dir: Path to global config directory (~/.config/wt)
         hook_dir_name: Hook directory name (e.g., "hooks/post_create.d")
 
     Returns:
@@ -78,14 +78,14 @@ def find_non_executable_hooks(
     """
     non_executable = []
 
-    # Local hooks (check directory exists, not just config file)
-    if local_config_path:
-        local_hook_dir = local_config_path.parent / hook_dir_name
+    # Local hooks
+    if local_base_dir:
+        local_hook_dir = local_base_dir / hook_dir_name
         if local_hook_dir.exists() and local_hook_dir.is_dir():
             non_executable.extend(_collect_non_executable_hooks(local_hook_dir))
 
     # Global hooks
-    global_hook_dir = global_config_path.parent / hook_dir_name
+    global_hook_dir = global_base_dir / hook_dir_name
     if global_hook_dir.exists() and global_hook_dir.is_dir():
         non_executable.extend(_collect_non_executable_hooks(global_hook_dir))
 
@@ -140,8 +140,8 @@ def build_hook_env(context: dict[str, str]) -> dict[str, str]:
 def run_post_create_hooks(
     worktree_path: Path,
     context: dict[str, str],
-    local_config_path: Path | None,
-    global_config_path: Path,
+    local_base_dir: Path | None,
+    global_base_dir: Path,
     config: dict,
 ) -> None:
     """Run post-create hooks for a new worktree.
@@ -149,8 +149,8 @@ def run_post_create_hooks(
     Args:
         worktree_path: Path to the new worktree
         context: Template context with variables
-        local_config_path: Path to local config (or None)
-        global_config_path: Path to global config
+        local_base_dir: Path to local .wt directory (or None if not present)
+        global_base_dir: Path to global config directory (~/.config/wt)
         config: Full config dictionary
 
     Raises:
@@ -162,13 +162,13 @@ def run_post_create_hooks(
     continue_on_error = config["hooks"]["continue_on_error"]
 
     # Check for non-executable hooks and warn
-    non_executable = find_non_executable_hooks(local_config_path, global_config_path, hook_dir_name)
+    non_executable = find_non_executable_hooks(local_base_dir, global_base_dir, hook_dir_name)
     for hook_path in non_executable:
         print(
             f"Warning: Hook '{hook_path}' is not executable. Run: chmod +x {hook_path}", flush=True
         )
 
-    hooks = discover_hooks(local_config_path, global_config_path, hook_dir_name)
+    hooks = discover_hooks(local_base_dir, global_base_dir, hook_dir_name)
 
     if not hooks:
         return


### PR DESCRIPTION
*I think* hooks should discover even if the user has not created `.wt/config.toml`. This rewires some internals to do hook discovery based on the location of the .wt directory (global or local) rather than the location of `.wt/config.toml`, which might not exist. 

Creating an empty `config.toml` works fine, but this avoids the gotcha.

Thanks for a great tool, @tdhopper.