### PR TITLE
Fix hook discovery without config.toml and reduce duplication

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -310,3 +310,27 @@ def test_new_from_current_errors_with_branch_arg(git_repo):
 
     assert result.returncode != 0, "Should fail when both branch and --from-current provided"
     assert "Cannot specify both" in result.stderr
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Shell hooks require Unix")
+def test_hooks_discovered_without_config_file(git_repo):
+    """Hooks should be discovered even when .wt/config.toml does not exist."""
+    repo = git_repo["repo"]
+    fake_home = git_repo["fake_home"]
+
+    # Create hook directory and script WITHOUT creating config.toml
+    hook_dir = repo / ".wt" / "hooks" / "post_create.d"
+    hook_dir.mkdir(parents=True)
+
+    hook_script = hook_dir / "00-test.sh"
+    hook_script.write_text("#!/bin/bash\necho 'HOOK_RAN_OK'\n")
+    hook_script.chmod(0o755)
+
+    # Verify config.toml does NOT exist
+    assert not (repo / ".wt" / "config.toml").exists()
+
+    # Create a worktree — the hook should run
+    result = run_wt(["new", "hook-test"], repo, fake_home, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"Failed: {result.stderr}"
+    assert "HOOK_RAN_OK" in result.stdout, f"Hook output not found in: {result.stdout}"

--- a/wt/cli.py
+++ b/wt/cli.py
@@ -150,15 +150,15 @@ def cmd_new(args, cfg, repo_root):  # noqa: PLR0912, PLR0915
         repo_root, wt_root, git_branch_name, source_branch, worktree_path
     )
 
-    local_config_path = config.get_local_config_path(repo_root)
-    global_config_path = config.get_global_config_path()
+    local_base_dir = config.get_local_base_dir(repo_root)
+    global_base_dir = config.get_global_base_dir()
 
     try:
         hooks.run_post_create_hooks(
             worktree_path,
             context,
-            local_config_path if local_config_path.exists() else None,
-            global_config_path,
+            local_base_dir,
+            global_base_dir,
             cfg,
         )
     except hooks.HookError as e:
@@ -508,23 +508,25 @@ def cmd_hooks_list(_args, cfg, repo_root):
     """List all hooks and their status."""
     hook_dir_name = cfg["hooks"]["post_create_dir"]
 
-    local_config_path = config.get_local_config_path(repo_root)
-    global_config_path = config.get_global_config_path()
+    local_base_dir = config.get_local_base_dir(repo_root)
+    global_base_dir = config.get_global_base_dir()
 
     # Determine hook directories
-    local_hook_dir = local_config_path.parent / hook_dir_name
-    global_hook_dir = global_config_path.parent / hook_dir_name
+    local_hook_dir = (
+        (local_base_dir / hook_dir_name) if local_base_dir else (repo_root / ".wt" / hook_dir_name)
+    )
+    global_hook_dir = global_base_dir / hook_dir_name
 
-    # Get all hooks (always pass local_config_path, hooks can exist without config file)
+    # Get all hooks
     executable_hooks = hooks.discover_hooks(
-        local_config_path,
-        global_config_path,
+        local_base_dir,
+        global_base_dir,
         hook_dir_name,
     )
 
     non_executable_hooks = hooks.find_non_executable_hooks(
-        local_config_path,
-        global_config_path,
+        local_base_dir,
+        global_base_dir,
         hook_dir_name,
     )
 
@@ -629,14 +631,15 @@ def cmd_doctor(_args, cfg, repo_root):  # noqa: PLR0912
     # Check hooks
     hook_dir = cfg["hooks"]["post_create_dir"]
 
-    all_hooks = hooks.discover_hooks(
-        local_config if local_config.exists() else None, global_config, hook_dir
-    )
+    local_base_dir = config.get_local_base_dir(repo_root)
+    global_base_dir = config.get_global_base_dir()
+
+    all_hooks = hooks.discover_hooks(local_base_dir, global_base_dir, hook_dir)
 
     if all_hooks:
         # Count local vs global by checking paths
-        local_hook_dir = local_config.parent / hook_dir if local_config.exists() else None
-        global_hook_dir = global_config.parent / hook_dir
+        local_hook_dir = local_base_dir / hook_dir if local_base_dir else None
+        global_hook_dir = global_base_dir / hook_dir
 
         local_count = sum(
             1 for h in all_hooks if local_hook_dir and h.is_relative_to(local_hook_dir)
@@ -650,9 +653,7 @@ def cmd_doctor(_args, cfg, repo_root):  # noqa: PLR0912
         print("  No hooks configured (optional)")
 
     # Check for non-executable hooks
-    non_executable = hooks.find_non_executable_hooks(
-        local_config if local_config.exists() else None, global_config, hook_dir
-    )
+    non_executable = hooks.find_non_executable_hooks(local_base_dir, global_base_dir, hook_dir)
     if non_executable:
         print(f"✗ Found {len(non_executable)} non-executable hook(s):")
         for hook in non_executable:

--- a/wt/config.py
+++ b/wt/config.py
@@ -71,6 +71,17 @@ def get_local_config_path(repo_root: Path) -> Path:
     return repo_root / ".wt" / "config.toml"
 
 
+def get_local_base_dir(repo_root: Path) -> Path | None:
+    """Return path to local .wt directory if it exists, else None."""
+    base = repo_root / ".wt"
+    return base if base.exists() else None
+
+
+def get_global_base_dir() -> Path:
+    """Return path to global config directory (~/.config/wt)."""
+    return Path.home() / ".config" / "wt"
+
+
 def load_config(
     repo_root: Path | None, cli_overrides: dict[str, Any] | None = None
 ) -> dict[str, Any]:

--- a/wt/hooks.py
+++ b/wt/hooks.py
@@ -10,15 +10,15 @@ class HookError(Exception):
 
 
 def discover_hooks(
-    local_config_path: Path | None,
-    global_config_path: Path,
+    local_base_dir: Path | None,
+    global_base_dir: Path,
     hook_dir_name: str,
 ) -> list[Path]:
     """Discover hook scripts in local and global directories.
 
     Args:
-        local_config_path: Path to local config file (or None)
-        global_config_path: Path to global config file
+        local_base_dir: Path to local .wt directory (or None)
+        global_base_dir: Path to global config directory (~/.config/wt)
         hook_dir_name: Hook directory name (e.g., "hooks/post_create.d")
 
     Returns:
@@ -27,14 +27,14 @@ def discover_hooks(
     """
     hooks = []
 
-    # Local hooks (check directory exists, not just config file)
-    if local_config_path:
-        local_hook_dir = local_config_path.parent / hook_dir_name
+    # Local hooks
+    if local_base_dir:
+        local_hook_dir = local_base_dir / hook_dir_name
         if local_hook_dir.exists() and local_hook_dir.is_dir():
             hooks.extend(_collect_executable_hooks(local_hook_dir))
 
     # Global hooks
-    global_hook_dir = global_config_path.parent / hook_dir_name
+    global_hook_dir = global_base_dir / hook_dir_name
     if global_hook_dir.exists() and global_hook_dir.is_dir():
         hooks.extend(_collect_executable_hooks(global_hook_dir))
 
@@ -61,15 +61,15 @@ def _collect_executable_hooks(directory: Path) -> list[Path]:
 
 
 def find_non_executable_hooks(
-    local_config_path: Path | None,
-    global_config_path: Path,
+    local_base_dir: Path | None,
+    global_base_dir: Path,
     hook_dir_name: str,
 ) -> list[Path]:
     """Find hook files that exist but are not executable.
 
     Args:
-        local_config_path: Path to local config file (or None)
-        global_config_path: Path to global config file
+        local_base_dir: Path to local .wt directory (or None)
+        global_base_dir: Path to global config directory (~/.config/wt)
         hook_dir_name: Hook directory name (e.g., "hooks/post_create.d")
 
     Returns:
@@ -78,14 +78,14 @@ def find_non_executable_hooks(
     """
     non_executable = []
 
-    # Local hooks (check directory exists, not just config file)
-    if local_config_path:
-        local_hook_dir = local_config_path.parent / hook_dir_name
+    # Local hooks
+    if local_base_dir:
+        local_hook_dir = local_base_dir / hook_dir_name
         if local_hook_dir.exists() and local_hook_dir.is_dir():
             non_executable.extend(_collect_non_executable_hooks(local_hook_dir))
 
     # Global hooks
-    global_hook_dir = global_config_path.parent / hook_dir_name
+    global_hook_dir = global_base_dir / hook_dir_name
     if global_hook_dir.exists() and global_hook_dir.is_dir():
         non_executable.extend(_collect_non_executable_hooks(global_hook_dir))
 
@@ -140,8 +140,8 @@ def build_hook_env(context: dict[str, str]) -> dict[str, str]:
 def run_post_create_hooks(
     worktree_path: Path,
     context: dict[str, str],
-    local_config_path: Path | None,
-    global_config_path: Path,
+    local_base_dir: Path | None,
+    global_base_dir: Path,
     config: dict,
 ) -> None:
     """Run post-create hooks for a new worktree.
@@ -149,8 +149,8 @@ def run_post_create_hooks(
     Args:
         worktree_path: Path to the new worktree
         context: Template context with variables
-        local_config_path: Path to local config (or None)
-        global_config_path: Path to global config
+        local_base_dir: Path to local .wt directory (or None)
+        global_base_dir: Path to global config directory (~/.config/wt)
         config: Full config dictionary
 
     Raises:
@@ -162,13 +162,13 @@ def run_post_create_hooks(
     continue_on_error = config["hooks"]["continue_on_error"]
 
     # Check for non-executable hooks and warn
-    non_executable = find_non_executable_hooks(local_config_path, global_config_path, hook_dir_name)
+    non_executable = find_non_executable_hooks(local_base_dir, global_base_dir, hook_dir_name)
     for hook_path in non_executable:
         print(
             f"Warning: Hook '{hook_path}' is not executable. Run: chmod +x {hook_path}", flush=True
         )
 
-    hooks = discover_hooks(local_config_path, global_config_path, hook_dir_name)
+    hooks = discover_hooks(local_base_dir, global_base_dir, hook_dir_name)
 
     if not hooks:
         return


### PR DESCRIPTION
## Summary

- Adds `get_local_base_dir()` and `get_global_base_dir()` helpers to `config.py` that return base directories (`.wt/`, `~/.config/wt/`) directly
- Refactors `hooks.py` functions to accept base directories instead of config file paths, removing the `.parent` indirection
- Updates all three call sites in `cli.py` (`cmd_new`, `cmd_hooks_list`, `cmd_doctor`), fixing the missed `find_non_executable_hooks` call in `cmd_doctor`
- Adds integration test verifying hooks run when `.wt/hooks/` exists but `config.toml` does not

Closes #14 — addresses the same bug with less duplication across call sites.

## Test plan

- [x] All 16 existing + new tests pass (`pytest tests/`)
- [ ] Manual: create repo with `.wt/hooks/post_create.d/` but no `config.toml`, run `wt new`, verify hook executes
- [ ] Manual: run `wt doctor` with hooks present but no config file, verify hooks are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)